### PR TITLE
[WHISPR-122] Add SonarQube project configuration

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,21 @@
+# Project identification
+sonar.projectKey=whispr-messenger_media-service_a74fabbd-72aa-43e4-a347-378a4bc8aa8b
+sonar.projectName=media-service
+sonar.projectVersion=1.0
+
+# Source code location
+sonar.sources=src
+sonar.tests=test
+
+# TypeScript/JavaScript specific settings
+sonar.typescript.lcov.reportPaths=coverage/lcov.info
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# Exclusions
+sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**
+
+# Test exclusions
+sonar.test.exclusions=**/*.spec.ts,**/*.test.ts
+
+# Encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Add sonar-project.properties with required project key and configuration settings
- Fixes CI workflow failure on main due to missing SonarQube configuration

## Test plan
- CI workflow should pass on this branch
- SonarQube analysis should complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)