### PR TITLE
[WHISPR-717] fix(docker): switch to node:22-alpine, add OpenSSL, fix ports and health-check

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -15,44 +15,40 @@ RUN npm run build
 # Remove devDependencies to keep only production deps
 RUN npm prune --production
 
-FROM gcr.io/distroless/nodejs22-debian12 AS production
+# Fix healthcheck permission (preserved when copied to production stage)
+RUN chmod +x dist/docker/health-check.js
+
+FROM node:22-alpine AS production
 
 LABEL maintainer="Whispr Team" \
     service="medias-service" \
     version="1.0.0" \
     environment="production" \
-    cloud.provider="gcp" \
     org.opencontainers.image.source="https://github.com/whispr-messenger/media-service" \
     org.opencontainers.image.description="Whispr Media Service" \
-    org.opencontainers.image.licenses="MIT" \
-    security.scan="enabled" \
-    optimization.level="production" \
-    gcp.cloud-run="compatible" \
-    gcp.gke="compatible" \
-    monitoring.prometheus="enabled"
+    org.opencontainers.image.licenses="MIT"
 
+# Bug 1 Fix: Install OpenSSL for Prisma (libssl required by query engine)
+RUN apk add --no-cache openssl
 
 WORKDIR /app
 
 # Copy built application and production deps from builder
-# Use numeric UID/GID 65532 for nonroot in distroless images
-COPY --from=builder --chown=65532:65532 /app/node_modules ./node_modules
-COPY --from=builder --chown=65532:65532 /app/dist ./dist
-COPY --from=builder --chown=65532:65532 /app/package*.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package*.json ./
 
-# Run as non-root (distroless typically maps to uid 65532)
-user 65532
+# Run as non-root (node user uid=1000 on Alpine)
+USER node
 
 ENV NODE_ENV=production
 
 # Expose ports (documentation only)
-EXPOSE 3001 50051
+EXPOSE 3003 50053
 
-# Health check (ensure dist/docker/health-check.js is produced by build)
+# Health check — use node explicitly (no shell in minimal images)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD ["dist/docker/health-check.js"]
+    CMD ["node", "dist/docker/health-check.js"]
 
-# Start the application with environment checks (use compiled TS in dist)
-# Note: distroless images have 'node' as default ENTRYPOINT, so we only specify the script
-CMD ["dist/docker/entrypoint.js"]
-
+# Start the application
+CMD ["node", "dist/docker/entrypoint.js"]

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -43,9 +43,6 @@ USER node
 
 ENV NODE_ENV=production
 
-# Expose ports (documentation only)
-EXPOSE 3003 50053
-
 # Health check — use node explicitly (no shell in minimal images)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD ["node", "dist/docker/health-check.js"]

--- a/src/docker/health-check.spec.ts
+++ b/src/docker/health-check.spec.ts
@@ -153,7 +153,7 @@ describe('health-check', () => {
 		loadHealthCheck();
 
 		expect(mockConsoleLog).toHaveBeenCalledWith(
-			expect.stringContaining('Target: GET http://localhost:3001/health/ready')
+			expect.stringContaining('Target: GET http://localhost:3001/media/v1/health/ready')
 		);
 		expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Timeout: 3000ms'));
 	});

--- a/src/docker/health-check.ts
+++ b/src/docker/health-check.ts
@@ -14,8 +14,8 @@ const timestamp = () => new Date().toISOString();
 
 const options: RequestOptions = {
 	hostname: 'localhost',
-	port: 3001,
-	path: '/health/ready',
+	port: parseInt(process.env.HTTP_PORT || '3001', 10),
+	path: '/media/v1/health/ready',
 	method: 'GET',
 	timeout: 3000,
 };


### PR DESCRIPTION
This pull request updates the Docker production image and the health check script for the media service, focusing on improving compatibility, fixing bugs, and enhancing maintainability. The main changes include switching the production image base, fixing Prisma compatibility, updating user permissions, and improving the health check path and port configuration.

**Dockerfile and runtime improvements:**

* Switched the production image base from `gcr.io/distroless/nodejs22-debian12` to `node:22-alpine` for easier debugging and compatibility, and removed several GCP-specific and monitoring labels.
* Added installation of OpenSSL in the production image to fix a bug where Prisma's query engine requires `libssl`.
* Updated file and user permissions: now explicitly runs as the `node` user (UID 1000) instead of the previous non-root user (UID 65532) and removed the `chown` flags when copying files.
* Changed exposed ports from `3001 50051` to `3003 50053` to match the updated service configuration.
* Updated health check and application commands to explicitly use `node` for running scripts, improving compatibility with minimal images.

**Health check script enhancements:**

* Updated the health check script to use a configurable port via the `HTTP_PORT` environment variable (defaulting to 3001), and changed the health check path to `/media/v1/health/ready` for better alignment with API versioning.