### PR TITLE
feat(moderation): add moderation fields, upload event, verdict endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: 🚀 CI Pipeline
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, deploy/avant-preprod, deploy/preprod]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, deploy/avant-preprod, deploy/preprod]
 
 permissions:
   contents: read

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -50,7 +50,7 @@ EXPOSE 3001 50051
 
 # Health check (ensure dist/docker/health-check.js is produced by build)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD ["dist/docker/health-check.js"]
+    CMD ["/nodejs/bin/node", "dist/docker/health-check.js"]
 
 # Start the application with environment checks (use compiled TS in dist)
 # Note: distroless images have 'node' as default ENTRYPOINT, so we only specify the script

--- a/src/config/migrations/1743200000000-AddModerationColumnsToMedia.ts
+++ b/src/config/migrations/1743200000000-AddModerationColumnsToMedia.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds moderation columns to the media table.
+ *
+ * These columns support content moderation for uploaded media:
+ * - moderation_status: tracks the current moderation state
+ * - moderation_score: confidence score from the moderation engine
+ * - moderation_category: the category flagged by the moderation engine
+ */
+export class AddModerationColumnsToMedia1743200000000 implements MigrationInterface {
+	name = 'AddModerationColumnsToMedia1743200000000';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`ALTER TABLE media.media ADD COLUMN moderation_status VARCHAR(32) NOT NULL DEFAULT 'none'`
+		);
+		await queryRunner.query(`ALTER TABLE media.media ADD COLUMN moderation_score FLOAT`);
+		await queryRunner.query(`ALTER TABLE media.media ADD COLUMN moderation_category VARCHAR(128)`);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE media.media DROP COLUMN moderation_category`);
+		await queryRunner.query(`ALTER TABLE media.media DROP COLUMN moderation_score`);
+		await queryRunner.query(`ALTER TABLE media.media DROP COLUMN moderation_status`);
+	}
+}

--- a/src/docker/health-check.spec.ts
+++ b/src/docker/health-check.spec.ts
@@ -153,7 +153,7 @@ describe('health-check', () => {
 		loadHealthCheck();
 
 		expect(mockConsoleLog).toHaveBeenCalledWith(
-			expect.stringContaining('Target: GET http://localhost:3001/health/ready')
+			expect.stringContaining('Target: GET http://localhost:3012/media/v1/health/ready')
 		);
 		expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Timeout: 3000ms'));
 	});

--- a/src/docker/health-check.ts
+++ b/src/docker/health-check.ts
@@ -14,8 +14,8 @@ const timestamp = () => new Date().toISOString();
 
 const options: RequestOptions = {
 	hostname: 'localhost',
-	port: 3001,
-	path: '/health/ready',
+	port: parseInt(process.env.HTTP_PORT || '3012', 10),
+	path: '/media/v1/health/ready',
 	method: 'GET',
 	timeout: 3000,
 };

--- a/src/modules/media/entities/media.entity.ts
+++ b/src/modules/media/entities/media.entity.ts
@@ -39,6 +39,15 @@ export class Media {
 	@Column({ name: 'is_active', type: 'boolean', default: true })
 	isActive: boolean;
 
+	@Column({ name: 'moderation_status', type: 'varchar', length: 32, default: 'none' })
+	moderationStatus: string; // 'none' | 'pending' | 'approved' | 'rejected' | 'manual_review'
+
+	@Column({ name: 'moderation_score', type: 'float', nullable: true })
+	moderationScore: number | null;
+
+	@Column({ name: 'moderation_category', type: 'varchar', length: 128, nullable: true })
+	moderationCategory: string | null;
+
 	@CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
 	createdAt: Date;
 

--- a/src/modules/media/media.controller.ts
+++ b/src/modules/media/media.controller.ts
@@ -3,6 +3,7 @@ import {
 	Post,
 	Get,
 	Delete,
+	Patch,
 	Param,
 	Headers,
 	UploadedFiles,
@@ -14,6 +15,7 @@ import {
 	BadRequestException,
 	Logger,
 	Body,
+	ParseUUIDPipe,
 } from '@nestjs/common';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import { ApiTags, ApiOperation, ApiResponse, ApiConsumes, ApiHeader, ApiBody } from '@nestjs/swagger';
@@ -176,5 +178,20 @@ export class MediaController {
 		const ip = (req.headers['x-forwarded-for'] as string) ?? req.socket?.remoteAddress;
 		const ua = req.headers['user-agent'];
 		await this.mediaService.delete(id, requesterId, ip, ua);
+	}
+
+	// =========================================================================
+	// PATCH /media/v1/:id/moderation — Moderation verdict
+	// =========================================================================
+
+	@Patch(':id/moderation')
+	@ApiOperation({ summary: 'Update moderation status (called by moderation-service)' })
+	@ApiResponse({ status: 200, description: 'Moderation status updated' })
+	@ApiResponse({ status: 404, description: 'Not found' })
+	async updateModeration(
+		@Param('id', ParseUUIDPipe) id: string,
+		@Body() body: { status: string; score?: number; category?: string }
+	) {
+		return this.mediaService.updateModerationStatus(id, body.status, body.score, body.category);
 	}
 }

--- a/src/modules/media/media.service.ts
+++ b/src/modules/media/media.service.ts
@@ -213,6 +213,12 @@ export class MediaService {
 
 			await this.dataSource.transaction((manager) => this.mediaRepository.save(media, manager));
 
+			// Only moderate image uploads in message context
+			if (context === MediaContext.MESSAGE && file.mimetype.startsWith('image/')) {
+				media.moderationStatus = 'pending';
+				await this.publishModerationEvent(media);
+			}
+
 			// Cache dedup entry
 			await this.cache.set(dedupKey, id, DEDUP_CACHE_TTL_MS);
 
@@ -397,6 +403,27 @@ export class MediaService {
 	}
 
 	// =========================================================================
+	// PATCH /media/v1/:id/moderation — Moderation verdict
+	// =========================================================================
+
+	async updateModerationStatus(
+		id: string,
+		status: string,
+		score?: number,
+		category?: string
+	): Promise<void> {
+		await this.dataSource.transaction(async (manager) => {
+			const media = await this.mediaRepository.findById(id, manager);
+			if (!media) throw new NotFoundException(`Media ${id} not found`);
+			media.moderationStatus = status;
+			if (score !== undefined) media.moderationScore = score;
+			if (category) media.moderationCategory = category;
+			await this.mediaRepository.save(media, manager);
+		});
+		this.logger.log(`Media ${id} moderation updated: ${status} (score=${score}, category=${category})`);
+	}
+
+	// =========================================================================
 	// Private helpers
 	// =========================================================================
 
@@ -503,6 +530,23 @@ export class MediaService {
 			context: media.context as MediaContext,
 			size: media.blobSize,
 		};
+	}
+
+	private async publishModerationEvent(media: Media): Promise<void> {
+		try {
+			await this.redisClient.publish(
+				'media.uploaded',
+				JSON.stringify({
+					mediaId: media.id,
+					ownerId: media.ownerId,
+					storagePath: media.storagePath,
+					contentType: media.contentType,
+				})
+			);
+			this.logger.log(`Published moderation event for media ${media.id}`);
+		} catch (err) {
+			this.logger.warn(`Failed to publish moderation event for media ${media.id}: ${err}`);
+		}
 	}
 
 	private async writeAccessLog(


### PR DESCRIPTION
Ajoute le support moderation au media-service :
- colonnes moderation_status, moderation_score, moderation_category
- event Redis media.uploaded apres upload d'image
- endpoint PATCH /media/v1/:id/moderation pour le verdict
- migration TypeORM