### PR TITLE
feat(cd): add CD pipeline with migration job image update

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,155 @@
+name: CD Pipeline
+
+on:
+  workflow_call:
+    inputs:
+      commit_sha:
+        description: 'Commit SHA to deploy'
+        required: true
+        type: string
+      ref:
+        description: 'Branch ref to deploy'
+        required: false
+        type: string
+        default: 'main'
+    secrets:
+      ACTIONS_CD:
+        required: true
+      ACTIONS_CD_PRIVATE_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit SHA to deploy (leave empty for latest)'
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/media-service
+
+jobs:
+  update-deployment:
+    runs-on: ubuntu-latest
+    name: Update Deployment Manifest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.ACTIONS_CD }}
+          private_key: ${{ secrets.ACTIONS_CD_PRIVATE_KEY }}
+
+      - name: Checkout media-service
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || 'main' }}
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Validate and determine commit SHA
+        id: validate_commit
+        run: |
+          # Determine the commit SHA from inputs
+          COMMIT_SHA="${{ inputs.commit_sha }}"
+
+          if [ -z "$COMMIT_SHA" ]; then
+            COMMIT_SHA="${{ github.sha }}"
+            echo "No commit SHA provided, using current: $COMMIT_SHA"
+          else
+            echo "Using provided commit SHA: $COMMIT_SHA"
+          fi
+
+          # Validate SHA format (7-40 hex characters)
+          if ! echo "$COMMIT_SHA" | grep -qE '^[a-fA-F0-9]{7,40}$'; then
+            echo "❌ Error: Invalid commit SHA format."
+            exit 1
+          fi
+
+          # Resolve to full SHA if short SHA was provided
+          if git rev-parse --verify "${COMMIT_SHA}^{commit}" >/dev/null 2>&1; then
+            COMMIT_SHA=$(git rev-parse --verify "${COMMIT_SHA}^{commit}")
+            echo "✅ Commit SHA resolved: $COMMIT_SHA"
+          else
+            echo "❌ Error: Commit SHA '${COMMIT_SHA}' does not exist in the repository."
+            exit 1
+          fi
+
+          # Store COMMIT_SHA as output for use in subsequent steps
+          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
+
+      - name: Checkout infrastructure repository
+        uses: actions/checkout@v4
+        with:
+          repository: whispr-messenger/infrastructure
+          ref: main
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Update image tag in deployment
+        id: update_image
+        run: |
+          # Use the validated commit SHA from the previous step
+          COMMIT_SHA="${{ steps.validate_commit.outputs.commit_sha }}"
+
+          # Extract short SHA safely using printf (7 characters, matching docker metadata-action default)
+          SHORT_SHA=$(printf "%.7s" "$COMMIT_SHA")
+
+          # Use the short SHA tag format that matches the CI docker workflow
+          IMAGE_TAG="sha-${SHORT_SHA}"
+
+          # Build the full image reference with lowercase (OCI requirement)
+          FULL_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${IMAGE_TAG}"
+          FULL_IMAGE=$(echo "${FULL_IMAGE}" | tr '[:upper:]' '[:lower:]')
+
+          echo "Commit SHA: $COMMIT_SHA"
+          echo "Short SHA: $SHORT_SHA"
+          echo "Image tag: $IMAGE_TAG"
+          echo "Updating deployment image to: ${FULL_IMAGE}"
+
+          # Update the deployment manifest in the infrastructure repository
+          yq -i ".spec.template.spec.containers[0].image = \"${FULL_IMAGE}\"" k8s/whispr/production/media-service/deployment.yaml
+
+          # Update the migration job manifest so PreSync always uses the same image
+          yq -i ".spec.template.spec.containers[0].image = \"${FULL_IMAGE}\"" k8s/whispr/production/media-service/migration-job.yaml
+
+      - name: Verify update
+        run: |
+          echo "Updated deployment manifest:"
+          yq '.spec.template.spec.containers[0].image' k8s/whispr/production/media-service/deployment.yaml
+          echo "Updated migration job manifest:"
+          yq '.spec.template.spec.containers[0].image' k8s/whispr/production/media-service/migration-job.yaml
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          # Check if there are changes to commit
+          if git diff --quiet k8s/whispr/production/media-service/deployment.yaml k8s/whispr/production/media-service/migration-job.yaml; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          # Use the validated commit SHA determined in the previous step
+          COMMIT_SHA="${{ steps.validate_commit.outputs.commit_sha }}"
+
+          # Build commit message based on trigger type
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            COMMIT_MSG="🔧 chore(deploy/media-service): update image to ${COMMIT_SHA:0:7} (manual trigger)"
+          else
+            COMMIT_MSG="🔧 chore(deploy/media-service): update image to ${COMMIT_SHA:0:7}"
+          fi
+
+          git add k8s/whispr/production/media-service/deployment.yaml k8s/whispr/production/media-service/migration-job.yaml
+          git commit -m "${COMMIT_MSG}"
+
+          git push https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/whispr-messenger/infrastructure.git main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,21 @@ name: 🚀 CI Pipeline
 on:
   push:
     branches: [main, develop, deploy/preprod]
+    paths-ignore:
+      - 'k8s/**'
+      - '**.md'
+      - 'documentation/**'
+      - '.github/workflows/cd.yml'
   pull_request:
     branches: [main, develop, deploy/preprod]
+    paths-ignore:
+      - 'k8s/**'
+      - '**.md'
+      - 'documentation/**'
+      - '.github/workflows/cd.yml'
 
 permissions:
-  contents: read
+  contents: write
   checks: write
   pull-requests: write
   packages: write
@@ -54,3 +64,28 @@ jobs:
     with:
       ref: ${{ github.ref }}
       should_deploy: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy/preprod') && github.event_name == 'push' }}
+
+  # ================================
+  # Deploy Gate (breaks the uses->uses chain forbidden by GitHub Actions)
+  # ================================
+  deploy_gate:
+    name: 🔒 Deploy Gate
+    runs-on: ubuntu-latest
+    needs: [docker]
+    if: needs.docker.result == 'success' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - run: echo "Docker succeeded, proceeding to deploy"
+
+  # ================================
+  # Deploy (only on main push, after Docker succeeds)
+  # ================================
+  deploy:
+    name: 🚀 Deploy
+    needs: [deploy_gate]
+    uses: ./.github/workflows/cd.yml
+    with:
+      commit_sha: ${{ github.sha }}
+      ref: main
+    secrets:
+      ACTIONS_CD: ${{ secrets.ACTIONS_CD }}
+      ACTIONS_CD_PRIVATE_KEY: ${{ secrets.ACTIONS_CD_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Create `cd.yml` for media-service following the auth-service pattern
- Updates both `deployment.yaml` and `migration-job.yaml` in the infrastructure repo on every push to main
- Wire `cd.yml` into `ci.yml` via `deploy_gate` and `deploy` jobs
- Add `paths-ignore` to CI for k8s/docs/cd changes

## Test plan
- [x] YAML syntax validated
- [ ] CI pipeline runs correctly on PR
- [ ] CD pipeline triggers on main push after merge

Closes WHISPR-645