### PR TITLE
[WHISPR-715] ci: add deploy/preprod to CI trigger branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: 🚀 CI Pipeline
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, deploy/preprod]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, deploy/preprod]
 
 permissions:
   contents: read

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -3,13 +3,12 @@ import { ConfigService } from '@nestjs/config';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { DocumentBuilder, SwaggerCustomOptions, SwaggerModule } from '@nestjs/swagger';
 
-function buildSwaggerDocument(port: number) {
+function buildSwaggerDocument(_port: number) {
 	return new DocumentBuilder()
 		.setTitle('Media Service')
 		.setDescription('API documentation for the Media Service')
 		.setVersion('1.0')
-		.addServer(`http://localhost:${port}`, 'Development')
-		.addServer('https://whispr.epitech-msc2026.me', 'Production')
+		.addServer('/', 'Current host')
 		.build();
 }
 


### PR DESCRIPTION
## Summary
- Add deploy/preprod branch to CI pipeline triggers (push + pull_request)
- Enables automatic CI when pushing to preprod branch

## Test plan
- [ ] CI triggers on push to deploy/preprod
- [ ] Existing main/develop triggers unaffected