### PR TITLE
[WHISPR-714] fix(swagger): use current host instead of hardcoded domains

### DIFF
--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -3,13 +3,12 @@ import { ConfigService } from '@nestjs/config';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { DocumentBuilder, SwaggerCustomOptions, SwaggerModule } from '@nestjs/swagger';
 
-function buildSwaggerDocument(port: number) {
+function buildSwaggerDocument(_port: number) {
 	return new DocumentBuilder()
 		.setTitle('Media Service')
 		.setDescription('API documentation for the Media Service')
 		.setVersion('1.0')
-		.addServer(`http://localhost:${port}`, 'Development')
-		.addServer('https://whispr.epitech-msc2026.me', 'Production')
+		.addServer('/', 'Current host')
 		.build();
 }
 


### PR DESCRIPTION
## Summary
- Replace hardcoded server URLs (epitech-msc2026.me, localhost) with relative path `/`
- Swagger 'Try it out' now works on any environment (prod, preprod, local)

## Test plan
- [ ] Swagger UI loads correctly
- [ ] 'Try it out' sends requests to the correct host