### PR TITLE
ci: enable Docker build and deploy for deploy/preprod branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: 🚀 CI Pipeline
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, deploy/preprod]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, deploy/preprod]
 
 permissions:
   contents: read
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/tests.yml
     with:
       ref: ${{ github.ref }}
-      should_deploy: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+      should_deploy: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy/preprod') && github.event_name == 'push' }}
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
@@ -41,7 +41,7 @@ jobs:
     uses: ./.github/workflows/trivy.yml
     with:
       ref: ${{ github.ref }}
-      should_deploy: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+      should_deploy: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy/preprod') && github.event_name == 'push' }}
 
   # ================================
   # Docker Build
@@ -53,4 +53,4 @@ jobs:
     uses: ./.github/workflows/docker.yml
     with:
       ref: ${{ github.ref }}
-      should_deploy: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+      should_deploy: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy/preprod') && github.event_name == 'push' }}


### PR DESCRIPTION
## Summary
- Add deploy/preprod to should_deploy condition in CI pipeline
- Docker images will now be built and pushed to GHCR when pushing to deploy/preprod
- No change to main branch behavior

## Test plan
- [ ] Push to main still triggers build+deploy
- [ ] Push to deploy/preprod now triggers build+deploy
- [ ] PR builds still skip deploy (event_name != push)