### PR TITLE
fix(build): add migration.config.ts and disable webpack bundling

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,7 +4,6 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "webpack": true,
-    "tsConfigPath": "tsconfig.json"
+    "tsConfigPath": "tsconfig.build.json"
   }
 }

--- a/src/migrations/migration.config.ts
+++ b/src/migrations/migration.config.ts
@@ -1,0 +1,35 @@
+import { DataSource } from 'typeorm';
+import { Media } from '../modules/media/entities/media.entity';
+import { UserQuota } from '../modules/media/entities/user-quota.entity';
+import { MediaAccessLog } from '../modules/media/entities/media-access-log.entity';
+
+const DEFAULT_POSTGRES_PORT = 5432;
+
+function parseDatabaseUrl(url: string) {
+	const parsed = new URL(url);
+	return {
+		host: parsed.hostname,
+		port: parseInt(parsed.port, 10) || DEFAULT_POSTGRES_PORT,
+		username: parsed.username,
+		password: parsed.password,
+		database: parsed.pathname.slice(1),
+	};
+}
+
+const databaseUrl = process.env.DB_URL;
+const dbConfig = databaseUrl
+	? parseDatabaseUrl(databaseUrl)
+	: {
+			host: process.env.DB_HOST || 'localhost',
+			port: parseInt(process.env.DB_PORT, 10) || DEFAULT_POSTGRES_PORT,
+			username: process.env.DB_USERNAME || 'postgres',
+			password: process.env.DB_PASSWORD || 'password',
+			database: process.env.DB_NAME || 'media_service',
+		};
+
+export default new DataSource({
+	type: 'postgres',
+	...dbConfig,
+	entities: [Media, UserQuota, MediaAccessLog],
+	migrations: [__dirname + '/../config/migrations/*{.ts,.js}'],
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}


### PR DESCRIPTION
The production image only produced dist/main.js because webpack was enabled, so the ArgoCD migration Job could not find dist/migrations/migration.config.js. Disable webpack so tsc emits individual files, add a standalone DataSource export for TypeORM CLI migrations, and add tsconfig.build.json to exclude test files.

Closes WHISPR-690