### PR TITLE
[WHSIPR-1190] fix(media): always presign avatar and group_icon URLs

### DIFF
--- a/src/modules/media/media.service.spec.ts
+++ b/src/modules/media/media.service.spec.ts
@@ -464,22 +464,26 @@ describe('MediaService', () => {
 			await expect(service.getBlob('media-uuid-1', 'stranger')).rejects.toThrow(ForbiddenException);
 		});
 
-		it('allows any user to download avatar blob (public context)', async () => {
+		// WHISPR-1190: avatars/group_icons stay readable by any authenticated user
+		// (ACL), but delivery is now via a presigned URL — the bucket is private.
+		it('allows any user to download avatar blob via a presigned URL', async () => {
 			const media = makeMedia({ ownerId: 'owner-1', context: MediaContext.AVATAR });
 			mockMediaRepository.findById.mockResolvedValue(media);
 
 			const result = await service.getBlob('media-uuid-1', 'different-user');
-			expect(result.url).toBe(`http://minio:9000/test-bucket/${media.storagePath}`);
-			expect(mockStorageService.getPublicUrl).toHaveBeenCalledWith(media.storagePath);
+			expect(result.url).toBe('https://presigned.url/file');
+			expect(result.expiresAt).toBeInstanceOf(Date);
+			expect(mockStorageService.getPublicUrl).not.toHaveBeenCalled();
 		});
 
-		it('allows any user to download group_icon blob (public context)', async () => {
+		it('allows any user to download group_icon blob via a presigned URL', async () => {
 			const media = makeMedia({ ownerId: 'owner-1', context: MediaContext.GROUP_ICON });
 			mockMediaRepository.findById.mockResolvedValue(media);
 
 			const result = await service.getBlob('media-uuid-1', 'different-user');
-			expect(result.url).toBe(`http://minio:9000/test-bucket/${media.storagePath}`);
-			expect(mockStorageService.getPublicUrl).toHaveBeenCalledWith(media.storagePath);
+			expect(result.url).toBe('https://presigned.url/file');
+			expect(result.expiresAt).toBeInstanceOf(Date);
+			expect(mockStorageService.getPublicUrl).not.toHaveBeenCalled();
 		});
 
 		// WHISPR-985: expiresAt must reflect regeneration, not the stale DB value
@@ -530,13 +534,16 @@ describe('MediaService', () => {
 				expect(mockMediaRepository.updateSignedUrlExpiry).not.toHaveBeenCalled();
 			});
 
-			it('returns expiresAt=null for a public-context blob', async () => {
+			// WHISPR-1190: public-readable contexts (AVATAR/GROUP_ICON) now go through
+			// the same presigning path as MESSAGE, so they always carry an expiry.
+			it('returns a non-null expiresAt for a public-readable avatar blob', async () => {
 				const media = makeMedia({ ownerId: 'owner-1', context: MediaContext.AVATAR });
 				mockMediaRepository.findById.mockResolvedValue(media);
+				mockMediaRepository.updateSignedUrlExpiry.mockResolvedValue(undefined);
 
 				const result = await service.getBlob('media-uuid-1', 'any-user');
 
-				expect(result.expiresAt).toBeNull();
+				expect(result.expiresAt).toBeInstanceOf(Date);
 			});
 		});
 
@@ -597,7 +604,8 @@ describe('MediaService', () => {
 			);
 		});
 
-		it('returns public URL for avatar thumbnail (no expiry)', async () => {
+		// WHISPR-1190: avatar thumbnails are now delivered via a presigned URL too.
+		it('returns presigned URL for avatar thumbnail with an expiry', async () => {
 			const media = makeMedia({
 				ownerId: 'owner-1',
 				context: MediaContext.AVATAR,
@@ -607,9 +615,9 @@ describe('MediaService', () => {
 
 			const result = await service.getThumbnail('media-uuid-1', 'any-user');
 
-			expect(result.url).toBe(`http://minio:9000/test-bucket/${media.thumbnailPath}`);
-			expect(result.expiresAt).toBeNull();
-			expect(mockStorageService.getPublicUrl).toHaveBeenCalledWith(media.thumbnailPath);
+			expect(result.url).toBe('https://presigned.url/file');
+			expect(result.expiresAt).toBeInstanceOf(Date);
+			expect(mockStorageService.getPublicUrl).not.toHaveBeenCalled();
 		});
 
 		it('throws NotFoundException when media does not exist', async () => {

--- a/src/modules/media/media.service.ts
+++ b/src/modules/media/media.service.ts
@@ -49,7 +49,11 @@ const CONTEXT_SIZE_LIMITS: Record<MediaContext, number> = {
 	[MediaContext.GROUP_ICON]: 5 * 1024 * 1024, // 5 MB
 };
 
-const PUBLIC_CONTEXTS = new Set<string>([MediaContext.AVATAR, MediaContext.GROUP_ICON]);
+// Contexts whose blobs are readable by any authenticated user (ACL only).
+// Delivery still goes through a presigned URL — the bucket is private and
+// `getPublicUrl` is intentionally never used here, so `profilePicturePrivacy`
+// (enforced upstream by user-service) is not bypassed by a guessable URL.
+const PUBLIC_READABLE_CONTEXTS = new Set<string>([MediaContext.AVATAR, MediaContext.GROUP_ICON]);
 
 // Thumbnails must always be a safe image type regardless of the blob context.
 const THUMBNAIL_ALLOWED_MIME = new Set<string>([
@@ -446,16 +450,8 @@ export class MediaService {
 			return { url: null, expiresAt: null };
 		}
 
-		const isPublic = PUBLIC_CONTEXTS.has(media.context);
-		let url: string;
-		let expiresAt: Date | null;
-		if (isPublic) {
-			url = this.storageService.getPublicUrl(media.thumbnailPath);
-			expiresAt = null;
-		} else {
-			url = await this.generatePresignedUrl(media.thumbnailPath, this.signedUrlExpirySeconds);
-			expiresAt = new Date(Date.now() + this.signedUrlExpirySeconds * 1000);
-		}
+		const url = await this.generatePresignedUrl(media.thumbnailPath, this.signedUrlExpirySeconds);
+		const expiresAt = new Date(Date.now() + this.signedUrlExpirySeconds * 1000);
 
 		this.writeAccessLog(media.id, requesterId, 'thumbnail', ipAddress, userAgent).catch((err) => {
 			this.logger.error(
@@ -747,7 +743,7 @@ export class MediaService {
 		sharedWith: string[] | null | undefined,
 		requesterId: string
 	): void {
-		if (PUBLIC_CONTEXTS.has(context)) return;
+		if (PUBLIC_READABLE_CONTEXTS.has(context)) return;
 		if (ownerId === requesterId) return;
 		if (sharedWith && sharedWith.includes(requesterId)) return;
 		throw new ForbiddenException('Access denied');
@@ -804,11 +800,6 @@ export class MediaService {
 		media: Media,
 		manager: EntityManager
 	): Promise<{ url: string; expiresAt: Date | null }> {
-		// Public contexts serve the blob via a non-signed URL — no expiry applies.
-		if (PUBLIC_CONTEXTS.has(media.context)) {
-			return { url: this.storageService.getPublicUrl(media.storagePath), expiresAt: null };
-		}
-
 		const now = new Date();
 		if (media.signedUrlExpiresAt && media.signedUrlExpiresAt > now) {
 			const remaining = Math.max(
@@ -857,33 +848,27 @@ export class MediaService {
 	/**
 	 * Construit la réponse de `POST /media/v1/upload` (WHISPR-917).
 	 *
-	 * - Contextes publics (avatars, group_icons) : URL publique statique.
-	 * - Contextes privés (messages) : URL présignée de courte durée, signée
-	 *   sur `S3_PUBLIC_ENDPOINT` si configuré, de sorte que le navigateur peut
-	 *   utiliser `url` directement dans `<img src>` sans header Authorization.
-	 * - Les clés suivent le nommage snake_case pour s'aligner sur les autres
-	 *   services REST (auth, user, messaging).
+	 * Tous les contextes (messages, avatars, group_icons) sont servis via une
+	 * URL presigned de courte durée signée sur `S3_PUBLIC_ENDPOINT` si
+	 * configuré, de sorte que le navigateur peut utiliser `url` directement
+	 * dans `<img src>` sans header Authorization.
+	 *
+	 * `expires_at` reflète la durée de vie de la signature, pas le TTL logique
+	 * du média. Les clés suivent le nommage snake_case pour s'aligner sur les
+	 * autres services REST (auth, user, messaging).
 	 */
 	private async buildUploadResponse(media: Media, _context: MediaContext): Promise<UploadMediaResponseDto> {
 		const presignExpiry = this.signedUrlExpirySeconds;
-		const isPublic = PUBLIC_CONTEXTS.has(media.context);
 
 		const url = media.storagePath
-			? isPublic
-				? this.storageService.getPublicUrl(media.storagePath)
-				: await this.generatePresignedUrl(media.storagePath, presignExpiry)
+			? await this.generatePresignedUrl(media.storagePath, presignExpiry)
 			: null;
 
 		const thumbnail_url = media.thumbnailPath
-			? isPublic
-				? this.storageService.getPublicUrl(media.thumbnailPath)
-				: await this.generatePresignedUrl(media.thumbnailPath, presignExpiry)
+			? await this.generatePresignedUrl(media.thumbnailPath, presignExpiry)
 			: null;
 
-		// Pour les contenus privés, expires_at reflète la durée de vie de la
-		// signature et non le TTL logique du média. Pour les contenus publics,
-		// on conserve le TTL logique (media.expiresAt).
-		const expires_at = isPublic ? media.expiresAt : new Date(Date.now() + presignExpiry * 1000);
+		const expires_at = new Date(Date.now() + presignExpiry * 1000);
 
 		return {
 			media_id: media.id,

--- a/test/upload-pipeline.e2e-spec.ts
+++ b/test/upload-pipeline.e2e-spec.ts
@@ -78,10 +78,10 @@ describe('Upload Pipeline (e2e, Docker)', () => {
 	}, 30000);
 
 	// =========================================================================
-	// Successful upload — avatar context (public URL returned)
+	// Successful upload — avatar context (presigned URL returned, WHISPR-1190)
 	// =========================================================================
 
-	it('uploads a JPEG avatar and returns a public URL', async () => {
+	it('uploads a JPEG avatar and returns a presigned URL with expiry', async () => {
 		const fileBuffer = Buffer.concat([JPEG_MAGIC, Buffer.alloc(512)]);
 
 		const res = await request(app.getHttpServer())
@@ -93,8 +93,11 @@ describe('Upload Pipeline (e2e, Docker)', () => {
 
 		expect(res.body.mediaId).toBeDefined();
 		expect(res.body.context).toBe('avatar');
-		// avatar is a public context — a URL should be returned
+		// WHISPR-1190: avatars are now delivered via a presigned URL too,
+		// so the bucket can stay private and `profilePicturePrivacy` is
+		// not bypassed by a guessable public URL.
 		expect(res.body.url).toBeTruthy();
+		expect(res.body.expires_at ?? res.body.expiresAt).toBeTruthy();
 	}, 30000);
 
 	// =========================================================================


### PR DESCRIPTION
## Summary

- `PUBLIC_CONTEXTS` court-circuitait le presigning pour `AVATAR` et `GROUP_ICON` en renvoyant une URL non signée pointant directement sur le bucket. Le bucket MinIO preprod étant privé, tout `GET` anonyme renvoyait `403 AccessDenied` → photos de profil cassées sur mobile.
- Suppression complète du chemin "URL publique" : tous les contextes passent désormais par `generatePresignedUrl`.
- Le rôle ACL (un user authentifié peut lire l'avatar/group_icon de n'importe qui) est conservé sous un nom plus explicite : `PUBLIC_READABLE_CONTEXTS`. Les deux concepts (lisibilité et mode de delivery) sont maintenant séparés.
- Bonus sécurité : ferme un trou où une URL publique connue court-circuitait `profilePicturePrivacy` (appliquée upstream par user-service).

`?stream=1` (commit cd78f8e) reste disponible comme fallback proxy bytes pour les clients qui ne peuvent pas atteindre l'endpoint MinIO.

## Test plan

- [x] `npx jest --no-coverage` → 362 passed
- [x] `npx eslint "src/**/*.ts" "test/**/*.ts"` → clean
- [x] `npx prettier --check ...` → clean
- [x] Pre-push hook (full unit suite) → green
- [ ] Validation manuelle preprod : `GET /media/v1/{id}/blob` pour un avatar retourne `{ url: <presigned MinIO>, expiresAt: <Date> }` et le mobile rend bien la photo de profil

Closes WHISPR-1190