### PR TITLE
ci: remove pull_request trigger to avoid duplicate CI runs on PRs to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,6 @@ on:
       - '**.md'
       - 'documentation/**'
       - '.github/workflows/cd.yml'
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - 'k8s/**'
-      - '**.md'
-      - 'documentation/**'
-      - '.github/workflows/cd.yml'
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

- The `push: branches: ['**']` trigger in `ci.yml` already runs CI on every commit of every branch — including the source branch of every PR.
- The `pull_request: branches: [main]` trigger only duplicated those runs for PRs targeting `main` (PRs targeting `deploy/preprod` were already single-run). Both runs were identical and provided no extra signal.
- Remove the `pull_request` trigger. Deployment is unaffected: the `deploy_gate` job already restricts deploys to `github.event_name == 'push'` AND `refs/heads/main` or `refs/heads/deploy/preprod`.

## Trade-off

CI will no longer run on PRs originating from **forks** (forks push to their own remote, not ours). Acceptable for a private repo without external contributors.

## Test plan

- [ ] CI green on this branch
- [ ] After merge: open a follow-up PR to `main` and confirm only one CI run is triggered (instead of two)
