### PR TITLE
test(media): coverage 90% + security rating A

### DIFF
--- a/src/docker/health-check.spec.ts
+++ b/src/docker/health-check.spec.ts
@@ -82,7 +82,7 @@ describe('health-check', () => {
 
 		expect(mockExit).toHaveBeenCalledWith(0);
 		expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Health check starting...'));
-		expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('✓ Health check PASSED'));
+		expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Health check PASSED'));
 		expect(mockRequest.end).toHaveBeenCalled();
 	});
 
@@ -102,7 +102,7 @@ describe('health-check', () => {
 		});
 
 		expect(mockExit).toHaveBeenCalledWith(1);
-		expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('✗ Health check FAILED'));
+		expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Health check FAILED'));
 		expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Invalid status code 500'));
 	});
 
@@ -122,7 +122,7 @@ describe('health-check', () => {
 
 		expect(mockExit).toHaveBeenCalledWith(1);
 		expect(mockConsoleError).toHaveBeenCalledWith(
-			expect.stringContaining('✗ Health check FAILED: Request error')
+			expect.stringContaining('Health check FAILED: Request error')
 		);
 		expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Connection refused'));
 	});
@@ -142,7 +142,7 @@ describe('health-check', () => {
 
 		expect(mockExit).toHaveBeenCalledWith(1);
 		expect(mockConsoleError).toHaveBeenCalledWith(
-			expect.stringContaining('✗ Health check FAILED: Request timeout after 3000ms')
+			expect.stringContaining('Health check FAILED: Request timeout after 3000ms')
 		);
 		expect(mockRequest.destroy).toHaveBeenCalled();
 	});
@@ -175,8 +175,27 @@ describe('health-check', () => {
 		});
 
 		expect(mockExit).toHaveBeenCalledWith(0);
+		expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Response body length:'));
+		expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('bytes'));
+	});
+
+	it('should accumulate buffer chunk lengths correctly', async () => {
+		mockHttpRequest(mockResponse);
+
+		loadHealthCheck();
+
+		await new Promise<void>((resolve) => {
+			process.nextTick(() => {
+				mockResponse.emit('data', Buffer.from('hello '));
+				mockResponse.emit('data', Buffer.from('world'));
+				mockResponse.emit('end');
+				process.nextTick(resolve);
+			});
+		});
+
+		expect(mockExit).toHaveBeenCalledWith(0);
 		expect(mockConsoleLog).toHaveBeenCalledWith(
-			expect.stringContaining('Response body: {"status":"ok"}')
+			expect.stringContaining('Response body length: 11 bytes')
 		);
 	});
 

--- a/src/docker/health-check.ts
+++ b/src/docker/health-check.ts
@@ -29,19 +29,19 @@ console.log(`[${timestamp()}] Timeout: ${options.timeout}ms`);
 const req = http.request(options, (res: http.IncomingMessage) => {
 	console.log(`[${timestamp()}] Response received with status code: ${res.statusCode}`);
 
-	let body = '';
-	res.on('data', (chunk) => {
-		body += chunk;
+	let bodyLength = 0;
+	res.on('data', (chunk: Buffer | string) => {
+		bodyLength += typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.length;
 	});
 
 	res.on('end', () => {
-		console.log(`[${timestamp()}] Response body: ${body}`);
+		console.log(`[${timestamp()}] Response body length: ${bodyLength} bytes`);
 
 		if (res.statusCode === 200) {
-			console.log(`[${timestamp()}] ✓ Health check PASSED`);
+			console.log(`[${timestamp()}] Health check PASSED`);
 			process.exit(0);
 		} else {
-			console.error(`[${timestamp()}] ✗ Health check FAILED: Invalid status code ${res.statusCode}`);
+			console.error(`[${timestamp()}] Health check FAILED: Invalid status code ${res.statusCode}`);
 			process.exit(1);
 		}
 	});

--- a/src/modules/media/dto/paginated-media-response.dto.spec.ts
+++ b/src/modules/media/dto/paginated-media-response.dto.spec.ts
@@ -1,0 +1,35 @@
+import { MediaItemDto, PaginatedMediaResponseDto } from './paginated-media-response.dto';
+
+describe('PaginatedMediaResponseDto', () => {
+	it('builds a media item with all fields', () => {
+		const item = new MediaItemDto();
+		item.id = 'm-1';
+		item.contentType = 'image/png';
+		item.blobSize = 1024;
+		item.context = 'message';
+		item.createdAt = new Date(0);
+		expect(item).toMatchObject({ id: 'm-1', contentType: 'image/png', blobSize: 1024 });
+	});
+
+	it('builds a paginated response with pagination metadata', () => {
+		const item = new MediaItemDto();
+		item.id = 'm-1';
+		item.contentType = 'image/png';
+		item.blobSize = 10;
+		item.context = 'message';
+		item.createdAt = new Date(0);
+
+		const response = new PaginatedMediaResponseDto();
+		response.items = [item];
+		response.total = 1;
+		response.page = 1;
+		response.limit = 20;
+		response.totalPages = 1;
+
+		expect(response.items).toHaveLength(1);
+		expect(response.total).toBe(1);
+		expect(response.page).toBe(1);
+		expect(response.limit).toBe(20);
+		expect(response.totalPages).toBe(1);
+	});
+});

--- a/src/modules/media/dto/upload-media.dto.spec.ts
+++ b/src/modules/media/dto/upload-media.dto.spec.ts
@@ -1,0 +1,166 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import {
+	BlobUrlResponseDto,
+	MediaContext,
+	MediaMetadataDto,
+	ShareMediaDto,
+	ShareMediaResponseDto,
+	ThumbnailUrlResponseDto,
+	UploadMediaDto,
+	UploadMediaResponseDto,
+} from './upload-media.dto';
+
+describe('UploadMediaDto', () => {
+	it('accepts a valid dto with no fields set', async () => {
+		const dto = plainToInstance(UploadMediaDto, {});
+		expect(await validate(dto)).toHaveLength(0);
+	});
+
+	it('accepts a valid context, ownerId and sharedWith array', async () => {
+		const dto = plainToInstance(UploadMediaDto, {
+			context: MediaContext.MESSAGE,
+			ownerId: '11111111-1111-4111-8111-111111111111',
+			sharedWith: ['22222222-2222-4222-8222-222222222222'],
+		});
+		expect(await validate(dto)).toHaveLength(0);
+	});
+
+	it('rejects an unknown context value', async () => {
+		const dto = plainToInstance(UploadMediaDto, { context: 'unknown' });
+		const errors = await validate(dto);
+		expect(errors.some((e) => e.property === 'context')).toBe(true);
+	});
+
+	it('rejects a non-uuid ownerId', async () => {
+		const dto = plainToInstance(UploadMediaDto, { ownerId: 'not-a-uuid' });
+		const errors = await validate(dto);
+		expect(errors.some((e) => e.property === 'ownerId')).toBe(true);
+	});
+
+	describe('sharedWith parsing', () => {
+		it('parses a CSV string into an array', async () => {
+			const dto = plainToInstance(UploadMediaDto, {
+				sharedWith: '11111111-1111-4111-8111-111111111111,22222222-2222-4222-8222-222222222222',
+			});
+			expect(dto.sharedWith).toEqual([
+				'11111111-1111-4111-8111-111111111111',
+				'22222222-2222-4222-8222-222222222222',
+			]);
+			expect(await validate(dto)).toHaveLength(0);
+		});
+
+		it('parses a JSON-encoded array string', async () => {
+			const dto = plainToInstance(UploadMediaDto, {
+				sharedWith: '["11111111-1111-4111-8111-111111111111"]',
+			});
+			expect(dto.sharedWith).toEqual(['11111111-1111-4111-8111-111111111111']);
+		});
+
+		it('falls back to the raw trimmed string when JSON.parse fails', async () => {
+			const dto = plainToInstance(UploadMediaDto, {
+				sharedWith: '[not-valid-json',
+			});
+			expect(dto.sharedWith).toBe('[not-valid-json');
+		});
+
+		it('falls back to the raw trimmed string when JSON parses to a non-array', async () => {
+			const dto = plainToInstance(UploadMediaDto, {
+				sharedWith: '[]extra',
+			});
+			expect(dto.sharedWith).toBe('[]extra');
+		});
+
+		it('passes through an existing array unchanged', async () => {
+			const dto = plainToInstance(UploadMediaDto, {
+				sharedWith: ['11111111-1111-4111-8111-111111111111'],
+			});
+			expect(dto.sharedWith).toEqual(['11111111-1111-4111-8111-111111111111']);
+		});
+
+		it('coerces non-string array members to strings', async () => {
+			const dto = plainToInstance(UploadMediaDto, {
+				sharedWith: [123, 456],
+			});
+			expect(dto.sharedWith).toEqual(['123', '456']);
+		});
+
+		it('returns undefined when sharedWith is null, empty string or undefined', async () => {
+			const cases: Array<unknown> = [null, '', undefined];
+			for (const value of cases) {
+				const dto = plainToInstance(UploadMediaDto, { sharedWith: value });
+				expect(dto.sharedWith).toBeUndefined();
+			}
+		});
+
+		it('filters out empty CSV entries', async () => {
+			const dto = plainToInstance(UploadMediaDto, {
+				sharedWith: '11111111-1111-4111-8111-111111111111,,22222222-2222-4222-8222-222222222222,',
+			});
+			expect(dto.sharedWith).toEqual([
+				'11111111-1111-4111-8111-111111111111',
+				'22222222-2222-4222-8222-222222222222',
+			]);
+		});
+
+		it('returns the raw value when not a string, array, null, or empty', async () => {
+			const dto = plainToInstance(UploadMediaDto, { sharedWith: { not: 'expected' } });
+			expect(dto.sharedWith).toEqual({ not: 'expected' });
+		});
+	});
+});
+
+describe('ShareMediaDto', () => {
+	it('accepts a valid array of UUIDs', async () => {
+		const dto = plainToInstance(ShareMediaDto, {
+			userIds: ['11111111-1111-4111-8111-111111111111'],
+		});
+		expect(await validate(dto)).toHaveLength(0);
+	});
+
+	it('rejects a non-uuid entry', async () => {
+		const dto = plainToInstance(ShareMediaDto, { userIds: ['not-a-uuid'] });
+		expect((await validate(dto)).length).toBeGreaterThan(0);
+	});
+});
+
+describe('Response DTO instantiation', () => {
+	it('UploadMediaResponseDto holds assigned values', () => {
+		const dto = new UploadMediaResponseDto();
+		dto.media_id = 'm-1';
+		dto.url = 'https://example';
+		dto.thumbnail_url = null;
+		dto.expires_at = new Date(0);
+		dto.context = MediaContext.AVATAR;
+		dto.size = 42;
+		expect(dto).toMatchObject({ media_id: 'm-1', size: 42, context: 'avatar' });
+	});
+
+	it('BlobUrlResponseDto, ThumbnailUrlResponseDto, ShareMediaResponseDto, MediaMetadataDto can be assigned', () => {
+		const blob = new BlobUrlResponseDto();
+		blob.url = 'u';
+		blob.expiresAt = null;
+		expect(blob.url).toBe('u');
+
+		const thumb = new ThumbnailUrlResponseDto();
+		thumb.url = null;
+		thumb.expiresAt = null;
+		expect(thumb.url).toBeNull();
+
+		const share = new ShareMediaResponseDto();
+		share.sharedWith = [];
+		expect(share.sharedWith).toEqual([]);
+
+		const meta = new MediaMetadataDto();
+		meta.id = '1';
+		meta.ownerId = '2';
+		meta.context = MediaContext.MESSAGE;
+		meta.contentType = 'image/png';
+		meta.blobSize = 1;
+		meta.expiresAt = null;
+		meta.isActive = true;
+		meta.createdAt = new Date(0);
+		meta.hasThumbnail = false;
+		expect(meta.contentType).toBe('image/png');
+	});
+});

--- a/src/modules/media/dto/user-quota-response.dto.spec.ts
+++ b/src/modules/media/dto/user-quota-response.dto.spec.ts
@@ -1,0 +1,32 @@
+import { UserQuotaResponseDto } from './user-quota-response.dto';
+
+describe('UserQuotaResponseDto', () => {
+	it('exposes all quota fields when populated', () => {
+		const dto = new UserQuotaResponseDto();
+		dto.storageUsed = 100;
+		dto.storageLimit = 1000;
+		dto.filesCount = 1;
+		dto.filesLimit = 50;
+		dto.dailyUploads = 0;
+		dto.dailyUploadLimit = 100;
+		dto.quotaDate = '2026-05-01';
+		dto.usagePercent = 10;
+
+		expect(dto).toMatchObject({
+			storageUsed: 100,
+			storageLimit: 1000,
+			filesCount: 1,
+			filesLimit: 50,
+			dailyUploads: 0,
+			dailyUploadLimit: 100,
+			quotaDate: '2026-05-01',
+			usagePercent: 10,
+		});
+	});
+
+	it('accepts a null quotaDate', () => {
+		const dto = new UserQuotaResponseDto();
+		dto.quotaDate = null;
+		expect(dto.quotaDate).toBeNull();
+	});
+});

--- a/src/modules/media/group.service.spec.ts
+++ b/src/modules/media/group.service.spec.ts
@@ -1,0 +1,185 @@
+import { ConfigService } from '@nestjs/config';
+import { GroupService } from './group.service';
+
+describe('GroupService', () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	const buildService = (overrides: Record<string, unknown> = {}): GroupService => {
+		const config: Record<string, unknown> = {
+			GROUP_SERVICE_URL: 'http://group-service:3000/',
+			GROUP_SERVICE_TIMEOUT_MS: 1500,
+			...overrides,
+		};
+		const configService = {
+			get: jest.fn((key: string, fallback?: unknown) =>
+				config[key] !== undefined ? config[key] : fallback
+			),
+		} as unknown as ConfigService;
+		return new GroupService(configService);
+	};
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		jest.restoreAllMocks();
+	});
+
+	it('strips a trailing slash from the configured base url', () => {
+		const service = buildService({ GROUP_SERVICE_URL: 'http://group-service:3000/' });
+		expect((service as unknown as { baseUrl: string }).baseUrl).toBe('http://group-service:3000');
+	});
+
+	it('throws when GROUP_SERVICE_URL is not configured', async () => {
+		const service = buildService({ GROUP_SERVICE_URL: '' });
+		await expect(service.isAdmin('group-1')).rejects.toThrow('GROUP_SERVICE_URL is not configured');
+	});
+
+	it('returns false when group-service responds 404', async () => {
+		const fetchMock = jest.fn().mockResolvedValue({ status: 404, ok: false });
+		globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+		const service = buildService();
+		await expect(service.isAdmin('group-1')).resolves.toBe(false);
+		expect(fetchMock).toHaveBeenCalledWith(
+			'http://group-service:3000/groups/v1/group-1/members',
+			expect.objectContaining({
+				headers: expect.objectContaining({ Accept: 'application/json' }),
+			})
+		);
+	});
+
+	it('returns false when group-service responds 403', async () => {
+		globalThis.fetch = jest.fn().mockResolvedValue({
+			status: 403,
+			ok: false,
+		}) as unknown as typeof globalThis.fetch;
+
+		const service = buildService();
+		await expect(service.isAdmin('group-1')).resolves.toBe(false);
+	});
+
+	it('throws when the response is not ok and not 403/404', async () => {
+		globalThis.fetch = jest.fn().mockResolvedValue({
+			status: 500,
+			ok: false,
+		}) as unknown as typeof globalThis.fetch;
+
+		const service = buildService();
+		await expect(service.isAdmin('group-1')).rejects.toThrow('group-service returned HTTP 500');
+	});
+
+	it('returns true when the user is admin and members are wrapped in a members property', async () => {
+		globalThis.fetch = jest.fn().mockResolvedValue({
+			status: 200,
+			ok: true,
+			json: async () => ({
+				members: [
+					{ userId: 'someone-else', role: 'admin' },
+					{ userId: 'group-1', role: 'admin' },
+				],
+			}),
+		}) as unknown as typeof globalThis.fetch;
+
+		const service = buildService();
+		await expect(service.isAdmin('group-1')).resolves.toBe(true);
+	});
+
+	it('returns true when the body is a bare members array and the user is admin', async () => {
+		globalThis.fetch = jest.fn().mockResolvedValue({
+			status: 200,
+			ok: true,
+			json: async () => [{ userId: 'group-1', role: 'admin' }],
+		}) as unknown as typeof globalThis.fetch;
+
+		const service = buildService();
+		await expect(service.isAdmin('group-1')).resolves.toBe(true);
+	});
+
+	it('returns false when the user is a non-admin member', async () => {
+		globalThis.fetch = jest.fn().mockResolvedValue({
+			status: 200,
+			ok: true,
+			json: async () => ({ members: [{ userId: 'group-1', role: 'member' }] }),
+		}) as unknown as typeof globalThis.fetch;
+
+		const service = buildService();
+		await expect(service.isAdmin('group-1')).resolves.toBe(false);
+	});
+
+	it('returns false when the body is missing a members field', async () => {
+		globalThis.fetch = jest.fn().mockResolvedValue({
+			status: 200,
+			ok: true,
+			json: async () => ({}),
+		}) as unknown as typeof globalThis.fetch;
+
+		const service = buildService();
+		await expect(service.isAdmin('group-1')).resolves.toBe(false);
+	});
+
+	it('passes a Bearer auth token when configured', async () => {
+		const fetchMock = jest.fn().mockResolvedValue({
+			status: 200,
+			ok: true,
+			json: async () => ({ members: [] }),
+		});
+		globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+		const service = buildService({ GROUP_SERVICE_AUTH_TOKEN: 'top-secret' });
+		await service.isAdmin('group-1');
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'http://group-service:3000/groups/v1/group-1/members',
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					Accept: 'application/json',
+					Authorization: 'Bearer top-secret',
+				}),
+			})
+		);
+	});
+
+	it('url-encodes the group id in the path', async () => {
+		const fetchMock = jest.fn().mockResolvedValue({
+			status: 200,
+			ok: true,
+			json: async () => ({ members: [] }),
+		});
+		globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+		const service = buildService();
+		await service.isAdmin('group with spaces/and slashes');
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'http://group-service:3000/groups/v1/group%20with%20spaces%2Fand%20slashes/members',
+			expect.any(Object)
+		);
+	});
+
+	it('clears the abort timer when the response resolves', async () => {
+		const clearSpy = jest.spyOn(globalThis, 'clearTimeout');
+		globalThis.fetch = jest.fn().mockResolvedValue({
+			status: 200,
+			ok: true,
+			json: async () => ({ members: [] }),
+		}) as unknown as typeof globalThis.fetch;
+
+		const service = buildService();
+		await service.isAdmin('group-1');
+		expect(clearSpy).toHaveBeenCalled();
+	});
+
+	it('clears the abort timer even when fetch rejects', async () => {
+		const clearSpy = jest.spyOn(globalThis, 'clearTimeout');
+		globalThis.fetch = jest
+			.fn()
+			.mockRejectedValue(new Error('network down')) as unknown as typeof globalThis.fetch;
+
+		const service = buildService();
+		await expect(service.isAdmin('group-1')).rejects.toThrow('network down');
+		expect(clearSpy).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Resume

Objectif: faire passer la couverture SonarCloud au-dessus de 90% et passer la security rating de B a A.

## Changements

- Fix de l'unique vulnerabilite ouverte (tssecurity:S5145, severity MINOR) sur `src/docker/health-check.ts`. Le script loggait le `body` brut renvoye par `/health/ready` (data depuis le reseau, donc considere user-controlled par Sonar). Maintenant on agrege uniquement la taille en octets, ce qui suffit pour debugger en cas de probleme et coupe le flux taint -> log.
- Suppression des emojis dans les messages de log du health-check au passage (juste pour rester sobre cote sortie docker).
- Nouveaux tests:
  - `group.service.spec.ts`: 100% sur `GroupService.isAdmin` (404/403, 5xx, body wrappe ou bare array, token bearer, encodage UUID, abort timer, etc.) - le module passait de 46% a 100%.
  - `upload-media.dto.spec.ts`: couvre le helper `parseStringArray` (CSV, JSON valide, JSON invalide, JSON non-array, array deja parse, valeurs vides).
  - `paginated-media-response.dto.spec.ts` et `user-quota-response.dto.spec.ts`: instanciation des DTOs pour fermer les % branches manquants.
- Tests health-check ajustes pour la nouvelle sortie (length au lieu de body) + nouveau cas Buffer chunks.

## Test plan

- [x] `npm test` -> 397 tests, 36 suites OK
- [x] Couverture locale jest passee de 80.99% a 82.11% global. SonarCloud filtre plus de fichiers (modules, types, migrations) donc le score y montait deja a 89.7%, avec ces ajouts on passe au-dessus de 90%.
- [ ] Verifier sur SonarCloud apres analyse PR que coverage > 90% et security = A.