### PR TITLE
[WHISPR-1297] docs(comments): cleanup em-dash + traduction FR

### DIFF
--- a/src/common/interceptors/logging.interceptor.ts
+++ b/src/common/interceptors/logging.interceptor.ts
@@ -1,2 +1,2 @@
-// Consolidated — canonical implementation lives in src/interceptors/logging.interceptor.ts
+// Consolidated - canonical implementation lives in src/interceptors/logging.interceptor.ts
 export { LoggingInterceptor } from '../../interceptors/logging.interceptor';

--- a/src/config/migrations/1742800000000-AddResetDailyUploadsFunction.ts
+++ b/src/config/migrations/1742800000000-AddResetDailyUploadsFunction.ts
@@ -7,7 +7,7 @@ export class AddResetDailyUploadsFunction1742800000000 implements MigrationInter
 		// SECURITY DEFINER makes this function execute with the privileges of its
 		// owner (the migration role / table owner) rather than the calling role.
 		// This allows the cron job to bypass the user_quotas RLS policy, which
-		// requires app.current_user_id to be set — a GUC that is unavailable in a
+		// requires app.current_user_id to be set - a GUC that is unavailable in a
 		// background cron context.
 		await queryRunner.query(`
 			CREATE OR REPLACE FUNCTION media.reset_daily_uploads()
@@ -40,7 +40,7 @@ export class AddResetDailyUploadsFunction1742800000000 implements MigrationInter
 		`);
 
 		// WHISPR-1004: keep the legacy `media_user` grant when (and only when)
-		// that role still exists — the local Docker init script provisions it,
+		// that role still exists - the local Docker init script provisions it,
 		// but Vault-backed envs don't. Without the existence check the whole
 		// migration crashes with `role "media_user" does not exist`.
 		await queryRunner.query(`

--- a/src/interceptors/logging.interceptor.ts
+++ b/src/interceptors/logging.interceptor.ts
@@ -5,7 +5,7 @@ import { tap } from 'rxjs/operators';
 import { Request, Response } from 'express';
 
 // WHISPR-1068 : émet des objets structurés au lieu d'un JSON.stringify
-// manuel — JsonLogger les fusionne avec les champs système. Ajoute aussi
+// manuel - JsonLogger les fusionne avec les champs système. Ajoute aussi
 // la propagation X-Request-Id (absente jusqu'ici côté media-service).
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,12 +36,12 @@ async function bootstrap() {
 
 	createSwaggerDocumentation(app, port, configService, globalPrefix);
 
-	// WHISPR-945: drop the previous `origin: true` — combined with
+	// WHISPR-945: drop the previous `origin: true` - combined with
 	// `credentials: true` it reflected every Origin header back, which is a
 	// CSRF vector against any authenticated browser session. We now read a
 	// comma-separated allowlist from CORS_ALLOWED_ORIGINS (matching the env
 	// var used by user-service and scheduling-service). When the env is
-	// unset we fail closed and emit no CORS headers — native iOS/Android
+	// unset we fail closed and emit no CORS headers - native iOS/Android
 	// clients are unaffected, only browser-based clients are blocked.
 	const allowedOrigins = String(configService.get<string>('CORS_ALLOWED_ORIGINS', '') ?? '')
 		.split(',')
@@ -65,7 +65,7 @@ async function bootstrap() {
 		logger.log(`CORS enabled for origins: ${allowedOrigins.join(', ')}`);
 	} else {
 		logger.warn(
-			'CORS_ALLOWED_ORIGINS is not set — browser clients will be blocked. ' +
+			'CORS_ALLOWED_ORIGINS is not set - browser clients will be blocked. ' +
 				'Configure the env var (comma-separated) to enable cross-origin access.'
 		);
 	}

--- a/src/modules/auth/jwt-auth.guard.ts
+++ b/src/modules/auth/jwt-auth.guard.ts
@@ -51,7 +51,7 @@ export class JwtAuthGuard implements CanActivate {
 
 		const publicKeyPem = this.jwksService.getPublicKeyPem();
 		if (!publicKeyPem) {
-			this.logger.warn('Public key not loaded — rejecting request');
+			this.logger.warn('Public key not loaded - rejecting request');
 			throw new UnauthorizedException();
 		}
 

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -8,7 +8,7 @@ import { InjectS3, S3 } from 'nestjs-s3';
 import { JwksService } from '../jwks/jwks.service';
 import { Public } from '../auth/public.decorator';
 
-// Health probes must never be rate-limited — kubelet hits them every few
+// Health probes must never be rate-limited - kubelet hits them every few
 // seconds and a 429 would cause pod flapping (WHISPR-1012).
 @SkipThrottle()
 @Public()

--- a/src/modules/media/dto/upload-media.dto.ts
+++ b/src/modules/media/dto/upload-media.dto.ts
@@ -59,7 +59,7 @@ export class UploadMediaDto {
 }
 
 export class ShareMediaDto {
-	// WHISPR-941 : PATCH /:id/share — liste d'UUIDs à ajouter à l'ACL.
+	// WHISPR-941 : PATCH /:id/share - liste d'UUIDs à ajouter à l'ACL.
 	@ApiProperty({
 		description: 'UUIDs to add to the shared_with ACL (union with existing)',
 		type: [String],

--- a/src/modules/media/lifecycle.service.spec.ts
+++ b/src/modules/media/lifecycle.service.spec.ts
@@ -103,7 +103,7 @@ describe('LifecycleService', () => {
 		expect(mockS3.send).toHaveBeenCalledTimes(2);
 	});
 
-	it('does not throw when ensureLifecyclePolicies fails — onApplicationBootstrap catches it', async () => {
+	it('does not throw when ensureLifecyclePolicies fails - onApplicationBootstrap catches it', async () => {
 		mockS3.send.mockRejectedValue(new Error('S3 error'));
 
 		await expect(service.onApplicationBootstrap()).resolves.toBeUndefined();

--- a/src/modules/media/lifecycle.service.ts
+++ b/src/modules/media/lifecycle.service.ts
@@ -16,9 +16,9 @@ import {
  * have changed in configuration, the rules are updated. Two prefixes
  * are currently covered:
  *
- * - `messages/`    — per-message blobs; TTL driven by MESSAGE_BLOB_TTL_DAYS
+ * - `messages/`    - per-message blobs; TTL driven by MESSAGE_BLOB_TTL_DAYS
  *                    (default: 30 days after the object's LastModified date)
- * - `thumbnails/`  — thumbnail blobs; TTL driven by THUMBNAIL_BLOB_TTL_DAYS
+ * - `thumbnails/`  - thumbnail blobs; TTL driven by THUMBNAIL_BLOB_TTL_DAYS
  *                    (default: 30 days)
  *
  * MinIO supports lifecycle policies via the AWS S3-compatible API, so no
@@ -79,7 +79,7 @@ export class LifecycleService implements OnApplicationBootstrap {
 				this.thumbnailBlobTtlDays;
 
 		if (rulesUpToDate) {
-			this.logger.log('S3 lifecycle policies already configured — skipping');
+			this.logger.log('S3 lifecycle policies already configured - skipping');
 			return;
 		}
 

--- a/src/modules/media/magic-bytes.validator.ts
+++ b/src/modules/media/magic-bytes.validator.ts
@@ -90,7 +90,7 @@ export function validateMagicBytes(buffer: Buffer, declaredMimeType: string): vo
 
 	const signatures = MAGIC_MAP[mime];
 	if (!signatures) {
-		// Unknown MIME type — not a type we validate
+		// Unknown MIME type - not a type we validate
 		return;
 	}
 

--- a/src/modules/media/media-access-log-partition.service.ts
+++ b/src/modules/media/media-access-log-partition.service.ts
@@ -27,7 +27,7 @@ export class MediaAccessLogPartitionService {
 		);
 
 		if (!acquired) {
-			this.logger.log(`Partition creation skipped — another instance holds the advisory lock`);
+			this.logger.log(`Partition creation skipped - another instance holds the advisory lock`);
 			return;
 		}
 

--- a/src/modules/media/media.controller.ts
+++ b/src/modules/media/media.controller.ts
@@ -45,16 +45,17 @@ import { UserQuotaResponseDto } from './dto/user-quota-response.dto';
 import { PaginatedMediaResponseDto } from './dto/paginated-media-response.dto';
 
 /**
- * Hard upper bound applied by multer / FileFieldsInterceptor so a malicious
- * client can't DoS the pod by streaming an unbounded body into memory
- * (WHISPR-1013). Per-context limits (MESSAGE=100MB, AVATAR/GROUP_ICON=5MB)
- * are still enforced at the service layer — this is the outer guard.
+ * Limite haute appliquee par multer / FileFieldsInterceptor pour qu'un
+ * client malveillant ne DoS pas le pod en streamant un body sans borne
+ * en memoire (WHISPR-1013). Les limites par contexte
+ * (MESSAGE=100MB, AVATAR/GROUP_ICON=5MB) restent enforce au niveau
+ * service, c'est juste le garde-fou exterieur.
  */
 export const UPLOAD_MAX_BYTES = 100 * 1024 * 1024;
 
 @ApiTags('Media')
 @ApiBearerAuth('bearer')
-@ApiResponse({ status: 401, description: 'Unauthorized — missing or invalid JWT token' })
+@ApiResponse({ status: 401, description: 'Non autorise - JWT manquant ou invalide' })
 @Controller()
 export class MediaController {
 	private readonly logger = new Logger(MediaController.name);
@@ -62,7 +63,7 @@ export class MediaController {
 	constructor(private readonly mediaService: MediaService) {}
 
 	// =========================================================================
-	// POST /media/v1/upload — WHISPR-359
+	// POST /media/v1/upload - WHISPR-359
 	// =========================================================================
 
 	@Post('upload')
@@ -119,7 +120,7 @@ export class MediaController {
 		if (!authenticatedUserId) {
 			throw new BadRequestException('Missing authenticated user');
 		}
-		// The ownerId in the body must match the authenticated user
+		// l'ownerId du body doit correspondre a l'user authentifie
 		const ownerId = dto.ownerId ?? authenticatedUserId;
 		if (ownerId !== authenticatedUserId) {
 			throw new BadRequestException('ownerId must match the authenticated user');
@@ -132,7 +133,7 @@ export class MediaController {
 	}
 
 	// =========================================================================
-	// GET /media/v1/quota — WHISPR-368
+	// GET /media/v1/quota - WHISPR-368
 	// =========================================================================
 
 	@Get('quota')
@@ -144,7 +145,7 @@ export class MediaController {
 	}
 
 	// =========================================================================
-	// GET /media/v1/my-media — WHISPR-375
+	// GET /media/v1/my-media - WHISPR-375
 	// =========================================================================
 
 	@Get('my-media')
@@ -170,7 +171,7 @@ export class MediaController {
 	}
 
 	// =========================================================================
-	// GET /media/v1/:id — WHISPR-364
+	// GET /media/v1/:id - WHISPR-364
 	// =========================================================================
 
 	@Get(':id')
@@ -188,7 +189,7 @@ export class MediaController {
 	}
 
 	// =========================================================================
-	// GET /media/v1/:id/blob — WHISPR-365
+	// GET /media/v1/:id/blob - WHISPR-365
 	// =========================================================================
 
 	// Retourne 200 JSON `{ url, expiresAt }` plutôt qu'un 302 : le redirect
@@ -232,7 +233,7 @@ export class MediaController {
 	}
 
 	// =========================================================================
-	// GET /media/v1/:id/thumbnail — WHISPR-366
+	// GET /media/v1/:id/thumbnail - WHISPR-366
 	// =========================================================================
 
 	// Même logique que /blob (200 JSON). Quand aucune thumbnail n'est stockée,
@@ -240,7 +241,7 @@ export class MediaController {
 	// permet au client de fallback silencieusement sur /blob. Avec `?stream=1`
 	// on sert les octets de la thumbnail via `StreamableFile` (404 si aucune
 	// thumbnail n'est stockée).
-	// WHISPR-1192: même override que /blob — les thumbnails sont chargés en
+	// WHISPR-1192: même override que /blob - les thumbnails sont chargés en
 	// même temps que les blobs (ou à leur place pour les vidéos), donc le
 	// même palier court 30/1s s'applique.
 	@Throttle({ short: { ttl: 1000, limit: 30 } })
@@ -278,7 +279,7 @@ export class MediaController {
 	}
 
 	// =========================================================================
-	// PATCH /media/v1/:id/share — ACL shared_with
+	// PATCH /media/v1/:id/share - ACL shared_with
 	// =========================================================================
 
 	@Patch(':id/share')
@@ -301,12 +302,12 @@ export class MediaController {
 	}
 
 	// =========================================================================
-	// DELETE /media/v1/:id — WHISPR-367
+	// DELETE /media/v1/:id - WHISPR-367
 	// =========================================================================
 
 	@Delete(':id')
 	@HttpCode(HttpStatus.NO_CONTENT)
-	@ApiOperation({ summary: 'Soft delete media — releases quota' })
+	@ApiOperation({ summary: 'Soft delete media - releases quota' })
 	@ApiParam({ name: 'id', description: 'Media UUID', type: String })
 	@ApiResponse({ status: 204, description: 'Deleted' })
 	@ApiResponse({ status: 403, description: 'Not owner' })

--- a/src/modules/media/media.module.ts
+++ b/src/modules/media/media.module.ts
@@ -43,7 +43,7 @@ import { RlsSubscriber } from './rls.subscriber';
 		LifecycleService,
 		RlsContextService,
 		RlsSubscriber,
-		// Global interceptor — applies to all routes including unauthenticated ones.
+		// Global interceptor - applies to all routes including unauthenticated ones.
 		// This is intentional: the interceptor is a no-op when userId is absent,
 		// and registering it globally avoids forgetting to apply it on new routes.
 		{

--- a/src/modules/media/media.service.spec.ts
+++ b/src/modules/media/media.service.spec.ts
@@ -346,7 +346,7 @@ describe('MediaService', () => {
 
 				await service.delete('media-uuid-1', 'user-uuid-1');
 
-				// publish is fire-and-forget — wait for microtasks to flush
+				// publish is fire-and-forget - wait for microtasks to flush
 				await Promise.resolve();
 
 				expect(mockRedisClient.publish).toHaveBeenCalledWith(
@@ -465,7 +465,7 @@ describe('MediaService', () => {
 		});
 
 		// WHISPR-1190: avatars/group_icons stay readable by any authenticated user
-		// (ACL), but delivery is now via a presigned URL — the bucket is private.
+		// (ACL), but delivery is now via a presigned URL - the bucket is private.
 		it('allows any user to download avatar blob via a presigned URL', async () => {
 			const media = makeMedia({ ownerId: 'owner-1', context: MediaContext.AVATAR });
 			mockMediaRepository.findById.mockResolvedValue(media);
@@ -636,7 +636,7 @@ describe('MediaService', () => {
 			expect(mockMetricsService.downloadsTotal.inc).toHaveBeenCalledTimes(1);
 		});
 
-		// An empty response (no thumbnail stored) is not a download — don't inflate the counter.
+		// An empty response (no thumbnail stored) is not a download - don't inflate the counter.
 		it('does not increment downloadsTotal when no thumbnail exists', async () => {
 			const media = makeMedia({ thumbnailPath: null });
 			mockMediaRepository.findById.mockResolvedValue(media);
@@ -895,7 +895,7 @@ describe('MediaService', () => {
 		});
 	});
 
-	describe('upload() — GROUP_ICON authorization (WHISPR-932)', () => {
+	describe('upload() - GROUP_ICON authorization (WHISPR-932)', () => {
 		const file: Express.Multer.File = {
 			originalname: 'icon.jpg',
 			mimetype: 'image/jpeg',

--- a/src/modules/media/media.service.ts
+++ b/src/modules/media/media.service.ts
@@ -42,20 +42,21 @@ import {
 	DEFAULT_DAILY_UPLOAD_LIMIT,
 } from './quota.constants';
 
-// Blob size limits per context (in bytes)
+// limites de taille des blobs par contexte (en bytes)
 const CONTEXT_SIZE_LIMITS: Record<MediaContext, number> = {
 	[MediaContext.MESSAGE]: 100 * 1024 * 1024, // 100 MB
 	[MediaContext.AVATAR]: 5 * 1024 * 1024, // 5 MB
 	[MediaContext.GROUP_ICON]: 5 * 1024 * 1024, // 5 MB
 };
 
-// Contexts whose blobs are readable by any authenticated user (ACL only).
-// Delivery still goes through a presigned URL — the bucket is private and
-// `getPublicUrl` is intentionally never used here, so `profilePicturePrivacy`
-// (enforced upstream by user-service) is not bypassed by a guessable URL.
+// contextes dont les blobs sont lisibles par n'importe quel user
+// authentifie (ACL uniquement). la delivery passe quand meme par une
+// URL presignee - le bucket reste prive et `getPublicUrl` n'est jamais
+// utilise ici expres, comme ca `profilePicturePrivacy` (enforce cote
+// user-service) n'est pas bypass par une URL devinable.
 const PUBLIC_READABLE_CONTEXTS = new Set<string>([MediaContext.AVATAR, MediaContext.GROUP_ICON]);
 
-// Thumbnails must always be a safe image type regardless of the blob context.
+// les thumbnails doivent toujours etre un type d'image safe, peu importe le contexte du blob
 const THUMBNAIL_ALLOWED_MIME = new Set<string>([
 	'image/jpeg',
 	'image/png',
@@ -66,7 +67,7 @@ const THUMBNAIL_ALLOWED_MIME = new Set<string>([
 ]);
 const THUMBNAIL_MAX_BYTES = 5 * 1024 * 1024;
 
-// Strict MIME allowlists per context — unknown types are rejected for uploads
+// allowlist MIME stricte par contexte - les types inconnus sont refuses a l'upload
 const CONTEXT_MIME_ALLOWLIST: Record<MediaContext, Set<string>> = {
 	[MediaContext.MESSAGE]: new Set([
 		'image/jpeg',
@@ -109,11 +110,11 @@ const CONTEXT_MIME_ALLOWLIST: Record<MediaContext, Set<string>> = {
 	]),
 };
 
-// Redis key TTLs
+// TTL des cles Redis
 const META_CACHE_TTL_MS = 30 * 60 * 1000; // 30 min
-const DEDUP_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
-const SEMAPHORE_TTL_SECONDS = 30 * 60; // 30 min safety net TTL in seconds
-const SEMAPHORE_TTL_REFRESH_INTERVAL_MS = 5 * 60 * 1000; // refresh every 5 min while uploading
+const DEDUP_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 jours
+const SEMAPHORE_TTL_SECONDS = 30 * 60; // 30 min, filet de securite TTL en secondes
+const SEMAPHORE_TTL_REFRESH_INTERVAL_MS = 5 * 60 * 1000; // refresh toutes les 5 min pendant l'upload
 
 const MAX_CONCURRENT_UPLOADS = 3;
 
@@ -166,7 +167,7 @@ export class MediaService {
 		const secretAccessKey = this.configService.get<string>('S3_SECRET_ACCESS_KEY');
 		if (!accessKeyId || !secretAccessKey) {
 			this.logger.warn(
-				'S3_PUBLIC_ENDPOINT set but credentials missing — falling back to internal S3 client for presigning'
+				'S3_PUBLIC_ENDPOINT set but credentials missing - falling back to internal S3 client for presigning'
 			);
 			return null;
 		}
@@ -192,7 +193,7 @@ export class MediaService {
 	}
 
 	// =========================================================================
-	// POST /media/v1/upload — WHISPR-359
+	// POST /media/v1/upload - WHISPR-359
 	// =========================================================================
 
 	async upload(
@@ -265,7 +266,7 @@ export class MediaService {
 
 				let thumbnailPath: string | null = null;
 				if (thumbnailFile) {
-					// Validate thumbnail: only safe image MIME types, max 5 MB, magic-bytes check
+					// validation thumbnail : seulement des MIME image safe, max 5 MB, check magic-bytes
 					if (!THUMBNAIL_ALLOWED_MIME.has(thumbnailFile.mimetype)) {
 						throw new UnsupportedMediaTypeException(
 							`Thumbnail MIME type '${thumbnailFile.mimetype}' is not allowed`
@@ -310,7 +311,7 @@ export class MediaService {
 
 				await this.dataSource.transaction((manager) => this.mediaRepository.save(media, manager));
 
-				// Cache dedup entry
+				// cache l'entree de dedup
 				await this.cache.set(dedupKey, id, DEDUP_CACHE_TTL_MS);
 
 				// WHISPR-357: Update quota
@@ -343,7 +344,7 @@ export class MediaService {
 	}
 
 	// =========================================================================
-	// GET /media/v1/:id — WHISPR-364
+	// GET /media/v1/:id - WHISPR-364
 	// =========================================================================
 
 	async getMetadata(id: string, requesterId: string): Promise<MediaMetadataDto> {
@@ -385,7 +386,7 @@ export class MediaService {
 	}
 
 	// =========================================================================
-	// GET /media/v1/:id/blob — WHISPR-365
+	// GET /media/v1/:id/blob - WHISPR-365
 	// =========================================================================
 
 	async getBlob(
@@ -411,7 +412,7 @@ export class MediaService {
 			return { media, url, expiresAt };
 		});
 
-		// Async access log (non-blocking)
+		// log d'acces asynchrone (non-bloquant)
 		this.writeAccessLog(media.id, requesterId, 'blob', ipAddress, userAgent).catch((err) => {
 			this.logger.error(
 				`Failed to write access log for media ${media.id}: ${err instanceof Error ? err.message : String(err)}`
@@ -424,7 +425,7 @@ export class MediaService {
 	}
 
 	// =========================================================================
-	// GET /media/v1/:id/thumbnail — WHISPR-366
+	// GET /media/v1/:id/thumbnail - WHISPR-366
 	// =========================================================================
 
 	async getThumbnail(
@@ -465,10 +466,10 @@ export class MediaService {
 	}
 
 	// =========================================================================
-	// GET /media/v1/:id/blob?stream=1 — fallback bytes proxy
+	// GET /media/v1/:id/blob?stream=1 - fallback bytes proxy
 	// =========================================================================
 
-	// Stream raw blob bytes back to the client. Used by clients that cannot
+	// stream les bytes bruts du blob vers le client. utilise par les clients qui ne peuvent pas
 	// reach the presigned URL hostname directly (typically mobile/web apps
 	// behind k8s when `S3_PUBLIC_ENDPOINT` is not configured and the signed
 	// URL points at a cluster-internal MinIO endpoint).
@@ -495,7 +496,7 @@ export class MediaService {
 		});
 	}
 
-	// Stream raw thumbnail bytes back to the client, or `null` when no
+	// stream les bytes bruts de la thumbnail vers le client, ou `null` si aucune
 	// thumbnail is stored (the controller converts that into a 404).
 	async streamThumbnail(
 		id: string,
@@ -518,12 +519,12 @@ export class MediaService {
 
 		// Le contentType de la thumbnail n'est pas persisté (seul celui du blob
 		// l'est). Les thumbnails sont toujours image/jpeg|png|gif|webp|heic|heif
-		// — on renvoie `image/*` laisser le client décoder par magic bytes.
+		// - on renvoie `image/*` laisser le client décoder par magic bytes.
 		return new StreamableFile(bodyStream, { type: 'image/*' });
 	}
 
 	// =========================================================================
-	// PATCH /media/v1/:id/share — ACL shared_with
+	// PATCH /media/v1/:id/share - ACL shared_with
 	// =========================================================================
 
 	/**
@@ -569,7 +570,7 @@ export class MediaService {
 	}
 
 	// =========================================================================
-	// DELETE /media/v1/:id — WHISPR-367
+	// DELETE /media/v1/:id - WHISPR-367
 	// =========================================================================
 
 	async delete(id: string, requesterId: string, ipAddress?: string, userAgent?: string): Promise<void> {
@@ -583,32 +584,32 @@ export class MediaService {
 				throw new ForbiddenException(`You do not own media ${id}`);
 			}
 
-			// Soft delete DB record first while the RLS GUC is set.
+			// soft delete en DB d'abord pendant que le GUC RLS est positionne
 			await this.mediaRepository.softDelete(id, manager);
 
 			return media;
 		});
 
-		// Delete underlying S3 objects so storage and quota stay in sync
+		// supprime les objets S3 sous-jacents pour que storage et quota restent alignes
 		await this.storageService.delete(media.storagePath);
 		if (media.thumbnailPath) {
 			await this.storageService.delete(media.thumbnailPath);
 		}
 
-		// Invalidate metadata cache
+		// invalide le cache des metadonnees
 		await this.cache.del(`media:meta:${id}`);
 
-		// Release quota
+		// libere le quota
 		await this.quotaService.recordDelete(requesterId, media.blobSize);
 
-		// Access log
+		// log d'acces
 		this.writeAccessLog(media.id, requesterId, 'delete', ipAddress, userAgent).catch((err) => {
 			this.logger.error(
 				`Failed to write access log for media ${media.id}: ${err instanceof Error ? err.message : String(err)}`
 			);
 		});
 
-		// WHISPR-372: Publish media.deleted event (fire-and-forget — failure does not affect the delete response)
+		// WHISPR-372: Publish media.deleted event (fire-and-forget - failure does not affect the delete response)
 		const deletedPayload = JSON.stringify({
 			mediaId: media.id,
 			ownerId: media.ownerId,
@@ -626,7 +627,7 @@ export class MediaService {
 	}
 
 	// =========================================================================
-	// GET /media/v1/quota — WHISPR-368
+	// GET /media/v1/quota - WHISPR-368
 	// =========================================================================
 
 	async getUserQuota(userId: string): Promise<UserQuotaResponseDto> {
@@ -665,7 +666,7 @@ export class MediaService {
 	}
 
 	// =========================================================================
-	// GET /media/v1/my-media — WHISPR-369
+	// GET /media/v1/my-media - WHISPR-369
 	// =========================================================================
 
 	async getUserMedia(userId: string, page: number, limit: number): Promise<PaginatedMediaResponseDto> {
@@ -694,7 +695,7 @@ export class MediaService {
 	}
 
 	// =========================================================================
-	// Private helpers
+	// helpers prives
 	// =========================================================================
 
 	private enforceContextSizeLimit(size: number, context: MediaContext): void {

--- a/src/modules/media/quota.service.spec.ts
+++ b/src/modules/media/quota.service.spec.ts
@@ -254,7 +254,7 @@ describe('QuotaService', () => {
 		it('executes atomic increment and invalidates cache', async () => {
 			const qb = mockUploadTransaction();
 			mockCache.del.mockResolvedValue(undefined);
-			// checkAndPublishQuotaAlert reads quota from cache — below threshold, no alert
+			// checkAndPublishQuotaAlert reads quota from cache - below threshold, no alert
 			mockCache.get.mockResolvedValue(makeCachedQuota({ storageUsed: 100n }));
 
 			await service.recordUpload('user-1', 512);

--- a/src/modules/media/quota.service.ts
+++ b/src/modules/media/quota.service.ts
@@ -269,7 +269,7 @@ export class QuotaService {
 			let row = await repo.findOne({ where: { userId } });
 
 			if (!row) {
-				// Upsert — concurrent inserts are handled by the unique index.
+				// Upsert - concurrent inserts are handled by the unique index.
 				// Use CURRENT_DATE (DB clock) to stay consistent with the cron reset.
 				await manager
 					.createQueryBuilder()
@@ -361,7 +361,7 @@ export class QuotaService {
 			EX: QUOTA_ALERT_COOLDOWN_TTL_SECONDS,
 		});
 		if (!acquired) {
-			// Cooldown active — skip publishing
+			// Cooldown active - skip publishing
 			return;
 		}
 

--- a/src/modules/media/rls.subscriber.ts
+++ b/src/modules/media/rls.subscriber.ts
@@ -55,10 +55,10 @@ export class RlsSubscriber implements EntitySubscriberInterface, OnModuleInit {
 		if (result?.[0]?.is_superuser === 'on') {
 			throw new Error(
 				'The database connection is using a superuser role. ' +
-					'Superusers bypass RLS policies — use a dedicated non-superuser role (e.g. media_app).'
+					'Superusers bypass RLS policies - use a dedicated non-superuser role (e.g. media_app).'
 			);
 		}
-		this.logger.log('Database role is non-superuser — RLS policies are active');
+		this.logger.log('Database role is non-superuser - RLS policies are active');
 	}
 
 	async afterTransactionStart(event: TransactionStartEvent): Promise<void> {

--- a/src/modules/metrics/metrics.controller.ts
+++ b/src/modules/metrics/metrics.controller.ts
@@ -6,7 +6,7 @@ import { Public } from '../auth/public.decorator';
 import { MetricsService } from './metrics.service';
 import { MetricsGuard } from './metrics.guard';
 
-// Prometheus scrape endpoint — already protected by MetricsGuard,
+// Prometheus scrape endpoint - already protected by MetricsGuard,
 // not subject to user-facing rate limiting (WHISPR-1012).
 @SkipThrottle()
 @Public()


### PR DESCRIPTION
## Summary
- Em-dash et en-dash remplaces par des tirets simples sur 19 fichiers src/
- Traduit en francais les commentaires anglais purs dans media.service.ts et media.controller.ts
- Aucune modification de code (logique inchangee)

## Test plan
- [x] npx jest --no-coverage (397/397)
- [x] npx eslint src/**/*.ts clean
- [x] npx prettier --check clean

Closes WHISPR-1297