### PR TITLE
[WHISPR-1322] chore(deps): bump @google-cloud/storage major v7 CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@aws-sdk/client-s3": "^3.1033.0",
 				"@aws-sdk/s3-request-presigner": "^3.1033.0",
 				"@google-cloud/secret-manager": "^6.1.1",
-				"@google-cloud/storage": "^6.12.0",
+				"@google-cloud/storage": "^7.19.0",
 				"@grpc/grpc-js": "^1.14.3",
 				"@grpc/proto-loader": "^0.8.0",
 				"@keyv/redis": "^5.1.5",
@@ -1227,18 +1227,6 @@
 				"fxparser": "src/cli/cli.js"
 			}
 		},
-		"node_modules/@aws-sdk/xml-builder/node_modules/strnum": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/@aws/lambda-invoke-store": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
@@ -2136,25 +2124,25 @@
 			}
 		},
 		"node_modules/@google-cloud/paginator": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.7.tgz",
-			"integrity": "sha512-jJNutk0arIQhmpUUQJPJErsojqo834KcyB6X7a1mxuic8i1tKXxde8E69IZxNZawRIlZdIK2QY4WALvlK5MzYQ==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+			"integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"arrify": "^2.0.0",
 				"extend": "^3.0.2"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@google-cloud/projectify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
-			"integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+			"integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
 			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=12.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@google-cloud/promisify": {
@@ -2179,32 +2167,29 @@
 			}
 		},
 		"node_modules/@google-cloud/storage": {
-			"version": "6.12.0",
-			"resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.12.0.tgz",
-			"integrity": "sha512-78nNAY7iiZ4O/BouWMWTD/oSF2YtYgYB3GZirn0To6eBOugjXVoK+GXgUXOl+HlqbAOyHxAVXOlsj3snfbQ1dw==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
+			"integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@google-cloud/paginator": "^3.0.7",
-				"@google-cloud/projectify": "^3.0.0",
-				"@google-cloud/promisify": "^3.0.0",
+				"@google-cloud/paginator": "^5.0.0",
+				"@google-cloud/projectify": "^4.0.0",
+				"@google-cloud/promisify": "<4.1.0",
 				"abort-controller": "^3.0.0",
 				"async-retry": "^1.3.3",
-				"compressible": "^2.0.12",
-				"duplexify": "^4.0.0",
-				"ent": "^2.2.0",
-				"extend": "^3.0.2",
-				"fast-xml-parser": "^4.2.2",
-				"gaxios": "^5.0.0",
-				"google-auth-library": "^8.0.1",
+				"duplexify": "^4.1.3",
+				"fast-xml-parser": "^5.3.4",
+				"gaxios": "^6.0.2",
+				"google-auth-library": "^9.6.3",
+				"html-entities": "^2.5.2",
 				"mime": "^3.0.0",
-				"mime-types": "^2.0.8",
 				"p-limit": "^3.0.1",
-				"retry-request": "^5.0.0",
-				"teeny-request": "^8.0.0",
+				"retry-request": "^7.0.0",
+				"teeny-request": "^9.0.0",
 				"uuid": "^8.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14"
 			}
 		},
 		"node_modules/@google-cloud/storage/node_modules/uuid": {
@@ -4486,6 +4471,18 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/@nodable/entities": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5545,7 +5542,7 @@
 			"version": "1.15.10",
 			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.10.tgz",
 			"integrity": "sha512-udNofxftduMUEv7nqahl2nvodCiCDQ4Ge0ebzsEm6P8s0RC2tBM0Hqx0nNF5J/6t9uagFJyWIDjXy3IIWMHDJw==",
-			"dev": true,
+			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -5587,7 +5584,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -5604,7 +5600,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -5621,7 +5616,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5638,7 +5632,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -5655,7 +5648,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -5672,7 +5664,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -5689,7 +5680,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -5706,7 +5696,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -5723,7 +5712,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -5740,7 +5728,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -5754,14 +5741,14 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
 			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@swc/types": {
 			"version": "0.1.25",
 			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
 			"integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/counter": "^0.1.3"
@@ -5804,9 +5791,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@tootallnate/once": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+			"integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10"
@@ -5913,6 +5900,12 @@
 				"@types/connect": "*",
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@types/caseless": {
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+			"integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+			"license": "MIT"
 		},
 		"node_modules/@types/compression": {
 			"version": "1.8.1",
@@ -6448,6 +6441,35 @@
 			"integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
 			"license": "MIT"
 		},
+		"node_modules/@types/request": {
+			"version": "2.48.13",
+			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+			"integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/caseless": "*",
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"form-data": "^2.5.5"
+			}
+		},
+		"node_modules/@types/request/node_modules/form-data": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+			"integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.35",
+				"safe-buffer": "^5.2.1"
+			},
+			"engines": {
+				"node": ">= 0.12"
+			}
+		},
 		"node_modules/@types/send": {
 			"version": "0.17.5",
 			"resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
@@ -6497,6 +6519,12 @@
 			"dependencies": {
 				"@types/superagent": "*"
 			}
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+			"license": "MIT"
 		},
 		"node_modules/@types/triple-beam": {
 			"version": "1.3.5",
@@ -7472,15 +7500,12 @@
 			}
 		},
 		"node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
 			"license": "MIT",
-			"dependencies": {
-				"debug": "4"
-			},
 			"engines": {
-				"node": ">= 6.0.0"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/ajv": {
@@ -7728,7 +7753,6 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/atomic-sleep": {
@@ -8868,7 +8892,6 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
@@ -9315,7 +9338,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
@@ -9561,21 +9583,6 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/ent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/ent/-/ent-2.2.2.tgz",
-			"integrity": "sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"es-errors": "^1.3.0",
-				"punycode": "^1.4.1",
-				"safe-regex-test": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/environment": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -9640,7 +9647,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
 			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -10385,12 +10391,6 @@
 			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
 			"license": "MIT"
 		},
-		"node_modules/fast-text-encoding": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
-			"integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
-			"license": "Apache-2.0"
-		},
 		"node_modules/fast-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -10408,9 +10408,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-xml-builder": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-			"integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -10419,13 +10419,14 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"path-expression-matcher": "^1.1.3"
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-			"integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+			"integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
 			"funding": [
 				{
 					"type": "github",
@@ -10434,7 +10435,10 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"strnum": "^1.1.1"
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.1.7",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.2.3"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -11009,31 +11013,56 @@
 			}
 		},
 		"node_modules/gaxios": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-			"integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+			"integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"extend": "^3.0.2",
-				"https-proxy-agent": "^5.0.0",
+				"https-proxy-agent": "^7.0.1",
 				"is-stream": "^2.0.0",
-				"node-fetch": "^2.6.9"
+				"node-fetch": "^2.6.9",
+				"uuid": "^9.0.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14"
+			}
+		},
+		"node_modules/gaxios/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/gcp-metadata": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-			"integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+			"integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"gaxios": "^5.0.0",
+				"gaxios": "^6.1.1",
+				"google-logging-utils": "^0.0.2",
 				"json-bigint": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14"
+			}
+		},
+		"node_modules/gcp-metadata/node_modules/google-logging-utils": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+			"integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/generic-pool": {
@@ -11228,23 +11257,20 @@
 			}
 		},
 		"node_modules/google-auth-library": {
-			"version": "8.9.0",
-			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.9.0.tgz",
-			"integrity": "sha512-f7aQCJODJFmYWN6PeNKzgvy9LI2tYmXnzpNDHEjG5sDNPgGb2FXQyTBnXeSH+PAtpKESFD+LmHw3Ox3mN7e1Fg==",
+			"version": "9.15.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+			"integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"arrify": "^2.0.0",
 				"base64-js": "^1.3.0",
 				"ecdsa-sig-formatter": "^1.0.11",
-				"fast-text-encoding": "^1.0.0",
-				"gaxios": "^5.0.0",
-				"gcp-metadata": "^5.3.0",
-				"gtoken": "^6.1.0",
-				"jws": "^4.0.0",
-				"lru-cache": "^6.0.0"
+				"gaxios": "^6.1.1",
+				"gcp-metadata": "^6.1.0",
+				"gtoken": "^7.0.0",
+				"jws": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14"
 			}
 		},
 		"node_modules/google-gax": {
@@ -11267,15 +11293,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/google-gax/node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/google-gax/node_modules/gaxios": {
@@ -11357,19 +11374,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/google-gax/node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/google-gax/node_modules/node-fetch": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
@@ -11440,22 +11444,6 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/google-p12-pem": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
-			"integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
-			"deprecated": "Package is no longer maintained",
-			"license": "MIT",
-			"dependencies": {
-				"node-forge": "^1.3.1"
-			},
-			"bin": {
-				"gp12-pem": "build/src/bin/gp12-pem.js"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
 		"node_modules/gopd": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -11509,17 +11497,16 @@
 			"license": "MIT"
 		},
 		"node_modules/gtoken": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
-			"integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+			"integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
 			"license": "MIT",
 			"dependencies": {
-				"gaxios": "^5.0.1",
-				"google-p12-pem": "^4.0.0",
+				"gaxios": "^6.0.0",
 				"jws": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/handlebars": {
@@ -11641,6 +11628,22 @@
 			"integrity": "sha512-51w+ZZGt7Zw5q7rM3nC4t3aLn/xvKDETsXqMczndvwyVQhAHfUmUuFBRFcos8Iyebtk7OAE9dL26wFNzZVVOkw==",
 			"license": "MIT"
 		},
+		"node_modules/html-entities": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+			"integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/mdevils"
+				},
+				{
+					"type": "patreon",
+					"url": "https://patreon.com/mdevils"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -11694,6 +11697,18 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/http-proxy-agent/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
 		"node_modules/http2-wrapper": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
@@ -11709,16 +11724,16 @@
 			}
 		},
 		"node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
 			"license": "MIT",
 			"dependencies": {
-				"agent-base": "6",
+				"agent-base": "^7.1.2",
 				"debug": "4"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/human-signals": {
@@ -12013,24 +12028,6 @@
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
 			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
 			"license": "MIT"
-		},
-		"node_modules/is-regex": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"gopd": "^1.2.0",
-				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
@@ -13898,18 +13895,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/luxon": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -14325,15 +14310,6 @@
 				"encoding": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/node-forge": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-			"integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-			"license": "(BSD-3-Clause OR GPL-2.0)",
-			"engines": {
-				"node": ">= 6.13.0"
 			}
 		},
 		"node_modules/node-gyp-build": {
@@ -15381,12 +15357,6 @@
 				"once": "^1.3.1"
 			}
 		},
-		"node_modules/punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-			"license": "MIT"
-		},
 		"node_modules/pure-rand": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -15711,16 +15681,17 @@
 			}
 		},
 		"node_modules/retry-request": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.2.tgz",
-			"integrity": "sha512-wfI3pk7EE80lCIXprqh7ym48IHYdwmAAzESdbU8Q9l7pnRCk9LEhpbOTNKjz6FARLm/Bl5m+4F0ABxOkYUujSQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+			"integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
 			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.1.1",
-				"extend": "^3.0.2"
+				"@types/request": "^2.48.8",
+				"extend": "^3.0.2",
+				"teeny-request": "^9.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14"
 			}
 		},
 		"node_modules/reusify": {
@@ -15870,23 +15841,6 @@
 				}
 			],
 			"license": "MIT"
-		},
-		"node_modules/safe-regex-test": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"es-errors": "^1.3.0",
-				"is-regex": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/safe-regex2": {
 			"version": "5.1.0",
@@ -16724,9 +16678,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-			"integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -16932,25 +16886,51 @@
 			}
 		},
 		"node_modules/teeny-request": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.3.tgz",
-			"integrity": "sha512-jJZpA5He2y52yUhA7pyAGZlgQpcB+xLjcN0eUFxr9c8hP/H7uOXbBNVo/O0C/xVfJLJs680jvkFgVJEEvk9+ww==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+			"integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"http-proxy-agent": "^5.0.0",
 				"https-proxy-agent": "^5.0.0",
-				"node-fetch": "^2.6.1",
+				"node-fetch": "^2.6.9",
 				"stream-events": "^1.0.5",
 				"uuid": "^9.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14"
+			}
+		},
+		"node_modules/teeny-request/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/teeny-request/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/teeny-request/node_modules/uuid": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
 			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
@@ -18292,6 +18272,21 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
 		},
 		"node_modules/xtend": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"@aws-sdk/client-s3": "^3.1033.0",
 		"@aws-sdk/s3-request-presigner": "^3.1033.0",
 		"@google-cloud/secret-manager": "^6.1.1",
-		"@google-cloud/storage": "^6.12.0",
+		"@google-cloud/storage": "^7.19.0",
 		"@grpc/grpc-js": "^1.14.3",
 		"@grpc/proto-loader": "^0.8.0",
 		"@keyv/redis": "^5.1.5",


### PR DESCRIPTION
## Summary

- Bump `@google-cloud/storage` from `^6.12.0` to `^7.19.0` to remove the CRITICAL `fast-xml-parser` CVE (entity encoding bypass via DOCTYPE entity names) pulled in transitively by GCS v6.
- The package is declared as a direct dep but only referenced in `src/test/setup.ts` as a `jest.mock(...)`, so no source code adaptation was required despite the major version jump.

## Breaking changes (v6 to v7) reviewed

- Node 14 minimum (we run Node 18+, fine).
- Stronger metadata typings, immutable options (`extend` removed), stronger lifecycle types.
- `delete()` now returns raw response only (no body).
- `bucket.setLabels` deprecated.
- Less client-side validation, source maps disabled.

None of these affect us because nothing imports the SDK in production code.

## Audit

- Before: `@google-cloud/storage` -> `teeny-request` -> `fast-xml-parser` (CRITICAL).
- After: `npm audit` -> `critical: 0`. The CRITICAL `fast-xml-parser` chain through GCS is gone.
- Residual moderate `fast-xml-parser` in the tree comes from `@aws-sdk/xml-builder` (different advisory, out of scope).

## Test plan

- [x] `npx jest --no-coverage` -> 397 tests pass
- [x] `npx tsc --noEmit` clean
- [x] `npm audit` -> 0 critical
- [x] e2e:docker tests fail identically on `deploy/preprod` baseline (pre-existing local DB env mismatch, not a regression)