### PR TITLE
fix(throttler): skip rate limiting on health probes (preventing 429 k8s cascade)

### DIFF
--- a/src/modules/health/health.controller.spec.ts
+++ b/src/modules/health/health.controller.spec.ts
@@ -1,10 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { HttpStatus } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Reflector } from '@nestjs/core';
 import { HealthController } from './health.controller';
 import { DataSource } from 'typeorm';
 import { getS3ConnectionToken } from 'nestjs-s3';
 import { JwksService } from '../jwks/jwks.service';
+
+// Cle interne du package nestjs/throttler - non exportee par le barrel.
+// Le decorateur stocke un flag par throttler nomme (ex: THROTTLER:SKIPshort).
+const THROTTLER_SKIP = 'THROTTLER:SKIP';
 
 describe('HealthController', () => {
 	let controller: HealthController;
@@ -40,6 +45,20 @@ describe('HealthController', () => {
 		controller = module.get<HealthController>(HealthController);
 
 		jest.clearAllMocks();
+	});
+
+	describe('throttler skip metadata', () => {
+		// Garde-fou: avec des throttlers nommes, @SkipThrottle() sans argument
+		// ne skip rien et fait flapper les pods en NotReady (429 sur readiness).
+		it.each(['short', 'medium', 'long'])(
+			'should skip the "%s" named throttler at controller level',
+			(name) => {
+				const reflector = new Reflector();
+				const skipped = reflector.get<boolean>(`${THROTTLER_SKIP}${name}`, HealthController);
+
+				expect(skipped).toBe(true);
+			}
+		);
 	});
 
 	describe('readiness()', () => {

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -8,9 +8,10 @@ import { InjectS3, S3 } from 'nestjs-s3';
 import { JwksService } from '../jwks/jwks.service';
 import { Public } from '../auth/public.decorator';
 
-// Health probes must never be rate-limited - kubelet hits them every few
-// seconds and a 429 would cause pod flapping (WHISPR-1012).
-@SkipThrottle()
+// Les probes kubelet tapent /health/ready toutes les 10s. Avec des throttlers
+// nommes (short/medium/long), @SkipThrottle() sans argument ne skip rien et
+// renvoie 429 apres 3 hits, ce qui fait flapper le pod en NotReady (WHISPR-1012).
+@SkipThrottle({ short: true, medium: true, long: true })
 @Public()
 @ApiTags('Health')
 @Controller('health')


### PR DESCRIPTION
## Summary

- `@SkipThrottle()` sans argument est inactif quand des throttlers nommes (`short`, `medium`, `long`) sont declares — la doc nestjs/throttler impose `{name: true}` par throttler.
- Resultat en preprod: kubelet tape `/media/v1/health/ready` toutes les 10s, le `SHORT_THROTTLER` (3 req/s) renvoie 429 a partir de la 4eme requete et fait flapper le pod en NotReady.
- Reproduction: 15 hits sequentiels depuis le pod renvoient `200 200 200 429 429 ...`.
- Fix: passer `{ short: true, medium: true, long: true }` au decorateur sur `HealthController`.
- Test garde-fou ajoute pour empecher la regression (cf. WHISPR-1012).

## Test plan

- [x] Unit tests verts (`npx jest --no-coverage`, 400 tests)
- [x] Lint clean
- [ ] Apres merge: `for i in {1..15}; do curl -s -o /dev/null -w "%{http_code} " http://127.0.0.1:3012/media/v1/health/ready; done` retourne 15x `200`

Closes WHISPR-1332