### PR TITLE
[WHISPR-1356] fix(media): writeAccessLog catch logging

### DIFF
--- a/src/modules/media/media.service.spec.ts
+++ b/src/modules/media/media.service.spec.ts
@@ -691,6 +691,23 @@ describe('MediaService', () => {
 			mockMediaRepository.findById.mockResolvedValue(null);
 			await expect(service.streamBlob('missing', 'user-uuid-1')).rejects.toThrow(NotFoundException);
 		});
+
+		// WHISPR-1356 - regression: l'audit trail ne doit JAMAIS s'evaporer
+		// silencieusement, sinon impossible de reconstituer un incident.
+		it('logs an error if writeAccessLog fails (audit trail must surface)', async () => {
+			const media = makeMedia();
+			mockMediaRepository.findById.mockResolvedValue(media);
+			mockStorageService.download.mockResolvedValueOnce(Readable.from(Buffer.from('x')));
+			mockAccessLogRepo.save.mockRejectedValueOnce(new Error('redis down'));
+			const errorSpy = jest.spyOn((service as any).logger, 'error').mockImplementation(() => {});
+
+			await service.streamBlob('media-uuid-1', 'user-uuid-1');
+			// laisse la promesse de log s'executer
+			await new Promise((resolve) => process.nextTick(resolve));
+
+			expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('redis down'));
+			errorSpy.mockRestore();
+		});
 	});
 
 	describe('streamThumbnail()', () => {
@@ -730,6 +747,23 @@ describe('MediaService', () => {
 			await expect(service.streamThumbnail('media-uuid-1', 'stranger')).rejects.toThrow(
 				ForbiddenException
 			);
+		});
+
+		// WHISPR-1356 - meme regression que streamBlob, sur le path thumbnail.
+		it('logs an error if writeAccessLog fails (audit trail must surface)', async () => {
+			const media = makeMedia({
+				thumbnailPath: 'thumbnails/user-uuid-1/media-uuid-1.bin',
+			});
+			mockMediaRepository.findById.mockResolvedValue(media);
+			mockStorageService.download.mockResolvedValueOnce(Readable.from(Buffer.from('x')));
+			mockAccessLogRepo.save.mockRejectedValueOnce(new Error('db unreachable'));
+			const errorSpy = jest.spyOn((service as any).logger, 'error').mockImplementation(() => {});
+
+			await service.streamThumbnail('media-uuid-1', 'user-uuid-1');
+			await new Promise((resolve) => process.nextTick(resolve));
+
+			expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('db unreachable'));
+			errorSpy.mockRestore();
 		});
 	});
 

--- a/src/modules/media/media.service.ts
+++ b/src/modules/media/media.service.ts
@@ -488,7 +488,11 @@ export class MediaService {
 		this.enforceReadAccess(media.context as MediaContext, media.ownerId, media.sharedWith, requesterId);
 
 		const bodyStream = await this.storageService.download(media.storagePath);
-		this.writeAccessLog(media.id, requesterId, 'blob', ipAddress, userAgent).catch(() => {});
+		this.writeAccessLog(media.id, requesterId, 'blob', ipAddress, userAgent).catch((err) => {
+			this.logger.error(
+				`Failed to write access log for media ${media.id}: ${err instanceof Error ? err.message : String(err)}`
+			);
+		});
 
 		return new StreamableFile(bodyStream, {
 			type: media.contentType,
@@ -515,7 +519,11 @@ export class MediaService {
 		if (!media.thumbnailPath) return null;
 
 		const bodyStream = await this.storageService.download(media.thumbnailPath);
-		this.writeAccessLog(media.id, requesterId, 'thumbnail', ipAddress, userAgent).catch(() => {});
+		this.writeAccessLog(media.id, requesterId, 'thumbnail', ipAddress, userAgent).catch((err) => {
+			this.logger.error(
+				`Failed to write access log for media ${media.id}: ${err instanceof Error ? err.message : String(err)}`
+			);
+		});
 
 		// Le contentType de la thumbnail n'est pas persisté (seul celui du blob
 		// l'est). Les thumbnails sont toujours image/jpeg|png|gif|webp|heic|heif


### PR DESCRIPTION
## Contexte

`streamBlob` et `streamThumbnail` (`src/modules/media/media.service.ts:491,518`) avalaient toute erreur de `writeAccessLog` via `.catch(() => {})`. Si Redis ou la DB de logs tombe, l'audit trail d'acces media disparait silencieusement — bloque toute incident response.

## Fix

On aligne ces 2 callsites sur le pattern deja utilise dans `getBlob` / `getThumbnail` / `delete` (lignes 416, 457, 606) :

```ts
.catch((err) => {
  this.logger.error(
    \`Failed to write access log for media \${media.id}: \${err instanceof Error ? err.message : String(err)}\`
  );
});
```

Le logger NestJS existe deja dans la classe (`MediaService.ts:123`). Pas de nouvelle dependance, pas de changement de signature publique.

## Tests

Ajout de 2 specs cibles :
- `streamBlob() logs an error if writeAccessLog fails`
- `streamThumbnail() logs an error if writeAccessLog fails`

Mockent `mockAccessLogRepo.save` pour rejecter, asserent que `logger.error` recoit bien le message d'erreur.

`npm test` : 402 / 402 verts.

## Risques

LOW. Changement strictement defensif :
- Aucun impact sur le path nominal (le `.catch` ne s'execute que si le log echoue).
- Pas de modif d'API publique, pas de modif de `writeAccessLog` lui-meme.
- Le logger.error est non-bloquant (fire-and-forget reste fire-and-forget).

Ticket: WHISPR-1356