### PR TITLE
[WHISPR-1371] fix(media): magic bytes avant MIME allowlist

### DIFF
--- a/src/modules/media/media.service.spec.ts
+++ b/src/modules/media/media.service.spec.ts
@@ -284,6 +284,26 @@ describe('MediaService', () => {
 				PayloadTooLargeException
 			);
 		});
+
+		// WHISPR-1371: defense-in-depth, magic-bytes doit etre verifie AVANT le MIME allowlist
+		it('rejects via magic-bytes before MIME allowlist when content is spoofed', async () => {
+			// MIME 'application/pdf' n'est pas dans l'allowlist AVATAR mais EST dans MAGIC_MAP.
+			// Buffer = JPEG. Sous l'ancien ordre on aurait eu un message "MIME not allowed".
+			// Sous le nouvel ordre, magic-bytes throw d'abord avec un message different.
+			const spoofed: Express.Multer.File = {
+				originalname: 'fake.pdf',
+				mimetype: 'application/pdf',
+				size: jpegBuffer.length,
+				buffer: jpegBuffer,
+			} as unknown as Express.Multer.File;
+
+			await expect(service.upload('user-uuid-1', spoofed, MediaContext.AVATAR)).rejects.toThrow(
+				/does not match the actual file content/
+			);
+			// ni l'allowlist ni le storage ne doivent avoir ete atteints
+			expect(mockStorageService.upload).not.toHaveBeenCalled();
+			expect(mockQuotaService.recordUpload).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('getMetadata()', () => {

--- a/src/modules/media/media.service.ts
+++ b/src/modules/media/media.service.ts
@@ -217,14 +217,16 @@ export class MediaService {
 				// WHISPR-361: Blob size limits per context
 				this.enforceContextSizeLimit(file.size, context);
 
-				// WHISPR-360: MIME allowlist + magic bytes validation
+				// WHISPR-360 / WHISPR-1371: magic bytes d'abord (defense-in-depth),
+				// puis MIME allowlist. Comme ca un fichier extension-spoofed est rejete
+				// avant qu'un futur audit/log/quota-claim soit declenche par le MIME declare.
+				const blobBuffer = file.buffer ?? Buffer.alloc(0);
+				validateMagicBytes(blobBuffer, file.mimetype);
 				if (!CONTEXT_MIME_ALLOWLIST[context].has(file.mimetype)) {
 					throw new UnsupportedMediaTypeException(
 						`MIME type '${file.mimetype}' is not allowed for context '${context}'`
 					);
 				}
-				const blobBuffer = file.buffer ?? Buffer.alloc(0);
-				validateMagicBytes(blobBuffer, file.mimetype);
 
 				// WHISPR-362: Blob deduplication via SHA-256 (scoped per owner+context)
 				const sha256 = createHash('sha256').update(blobBuffer).digest('hex');
@@ -266,7 +268,10 @@ export class MediaService {
 
 				let thumbnailPath: string | null = null;
 				if (thumbnailFile) {
-					// validation thumbnail : seulement des MIME image safe, max 5 MB, check magic-bytes
+					// validation thumbnail : magic-bytes d'abord (defense-in-depth),
+					// puis MIME allowlist + size cap.
+					const thumbBuffer = thumbnailFile.buffer ?? Buffer.alloc(0);
+					validateMagicBytes(thumbBuffer, thumbnailFile.mimetype);
 					if (!THUMBNAIL_ALLOWED_MIME.has(thumbnailFile.mimetype)) {
 						throw new UnsupportedMediaTypeException(
 							`Thumbnail MIME type '${thumbnailFile.mimetype}' is not allowed`
@@ -277,8 +282,6 @@ export class MediaService {
 							`Thumbnail size ${thumbnailFile.size} exceeds the 5 MB limit`
 						);
 					}
-					const thumbBuffer = thumbnailFile.buffer ?? Buffer.alloc(0);
-					validateMagicBytes(thumbBuffer, thumbnailFile.mimetype);
 
 					const thumbnailStoragePath = this.storageService.buildPath('thumbnails', ownerId, id);
 					const thumbStream = thumbnailFile.stream ?? Readable.from(thumbBuffer);


### PR DESCRIPTION
## Summary
- Inverse l'ordre des checks a l'upload : magic-bytes valide le buffer AVANT le MIME allowlist (defense-in-depth).
- Meme swap pour le thumbnail.
- Empeche un fichier extension-spoofed de declencher un futur side-effect (audit log, claim quota, telemetrie) qui se baserait sur le MIME declare par le client avant la verif reelle.

## Test plan
- [x] Unit tests verts (403/403)
- [x] Lint clean
- [x] Nouveau test "rejects via magic-bytes before MIME allowlist when content is spoofed" qui prouve que magic-bytes intercepte avant le MIME check (MIME=application/pdf, buffer=JPEG, contexte AVATAR : ancien ordre aurait throw "MIME not allowed", nouveau ordre throw "does not match the actual file content")

Closes WHISPR-1371