### PR TITLE
[WHISPR-1411] fix(security): presigned URL default 1h

### DIFF
--- a/src/config/env-validation.schema.ts
+++ b/src/config/env-validation.schema.ts
@@ -21,7 +21,8 @@ export const envValidationSchema = Joi.object({
 	S3_ENDPOINT: Joi.string().required(),
 	S3_PUBLIC_ENDPOINT: Joi.string().uri().optional(),
 	S3_REGION: Joi.string().optional().default('us-east-1'),
-	SIGNED_URL_EXPIRY_SECONDS: Joi.number().integer().positive().max(604800).optional().default(604800),
+	// 1h limite fenetre d'exploitation post-revoke (was 7j)
+	SIGNED_URL_EXPIRY_SECONDS: Joi.number().integer().positive().max(604800).optional().default(3600),
 	MESSAGE_BLOB_TTL_DAYS: Joi.number().integer().positive().optional().default(30),
 	THUMBNAIL_BLOB_TTL_DAYS: Joi.number().integer().positive().optional().default(30),
 }).options({ allowUnknown: true });

--- a/src/modules/media/media.service.spec.ts
+++ b/src/modules/media/media.service.spec.ts
@@ -101,7 +101,7 @@ const mockS3 = {
 const mockConfigService = {
 	get: jest.fn((key: string, defaultValue?: unknown) => {
 		const config: Record<string, unknown> = {
-			SIGNED_URL_EXPIRY_SECONDS: 604800,
+			SIGNED_URL_EXPIRY_SECONDS: 3600,
 			MESSAGE_BLOB_TTL_DAYS: 30,
 		};
 		return config[key] ?? defaultValue;
@@ -508,7 +508,7 @@ describe('MediaService', () => {
 
 		// WHISPR-985: expiresAt must reflect regeneration, not the stale DB value
 		describe('expiresAt on signed URL regeneration (WHISPR-985)', () => {
-			const SIGNED_URL_EXPIRY_SECONDS = 604800; // matches mockConfigService default
+			const SIGNED_URL_EXPIRY_SECONDS = 3600; // matches mockConfigService default
 
 			it('returns a freshly computed expiresAt when no cached expiry exists', async () => {
 				const media = makeMedia({ signedUrlExpiresAt: null });

--- a/src/modules/media/media.service.ts
+++ b/src/modules/media/media.service.ts
@@ -147,10 +147,8 @@ export class MediaService {
 		private readonly metricsService: MetricsService,
 		private readonly groupService: GroupService
 	) {
-		this.signedUrlExpirySeconds = this.configService.get<number>(
-			'SIGNED_URL_EXPIRY_SECONDS',
-			7 * 24 * 60 * 60
-		);
+		// 1h limite fenetre d'exploitation post-revoke (was 7j)
+		this.signedUrlExpirySeconds = this.configService.get<number>('SIGNED_URL_EXPIRY_SECONDS', 60 * 60);
 		this.presigner = this.buildPresignerClient();
 	}
 


### PR DESCRIPTION
## Summary

- Reduce `SIGNED_URL_EXPIRY_SECONDS` default from `604800` (7 days) to `3600` (1 hour).
- A presigned S3/MinIO URL valid 7 days cannot be revoked in DB - if a message is deleted or a user is banned, the URL stays usable until expiry.
- 1h shrinks the post-revoke exploitation window drastically. Mobile clients re-fetch on demand if the user replays media.
- Override via `SIGNED_URL_EXPIRY_SECONDS` env var still supported (max cap kept at 7d).

## Files

- `src/config/env-validation.schema.ts` - Joi default `604800` -> `3600`
- `src/modules/media/media.service.ts` - fallback `7*24*60*60` -> `60*60`
- `src/modules/media/media.service.spec.ts` - tests adapted to new default

## Test plan

- [x] Unit tests green (`npx jest --no-coverage` -> 403/403)
- [x] Lint clean
- [ ] CI green
- [ ] Sonar quality gate OK

Closes WHISPR-1411