### PR TITLE
feat(media): content safety - image bomb, PDF JS scan, ClamAV stub

### DIFF
--- a/src/modules/media/content-safety.validator.spec.ts
+++ b/src/modules/media/content-safety.validator.spec.ts
@@ -1,0 +1,112 @@
+import { PayloadTooLargeException, UnprocessableEntityException } from '@nestjs/common';
+import * as sharp from 'sharp';
+import { checkImageDimensions, checkPdfJavaScript, checkClamAv } from './content-safety.validator';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/** Génère un buffer PNG minimal pour un test de dimensions. */
+async function makePng(width: number, height: number): Promise<Buffer> {
+	return sharp({
+		create: { width, height, channels: 3, background: { r: 0, g: 0, b: 0 } },
+	})
+		.png()
+		.toBuffer();
+}
+
+/** Buffer PDF minimaliste sans JavaScript. */
+function makePdfClean(): Buffer {
+	return Buffer.from('%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n');
+}
+
+/** Buffer PDF avec un token /JavaScript embarqué. */
+function makePdfWithJs(): Buffer {
+	return Buffer.from('%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Names << /JavaScript 2 0 R >> >>\nendobj\n');
+}
+
+// ── checkImageDimensions() ───────────────────────────────────────────────────
+
+describe('checkImageDimensions()', () => {
+	it('passe pour une image dans les limites (200x200)', async () => {
+		const buf = await makePng(200, 200);
+		await expect(checkImageDimensions(buf, 'image/png')).resolves.toBeUndefined();
+	});
+
+	it('rejette une image trop grande (>50 MP)', async () => {
+		// 7071 x 7072 ≈ 50 003 312 px > 50 000 000
+		const buf = await makePng(7072, 7072);
+		await expect(checkImageDimensions(buf, 'image/png')).rejects.toThrow(PayloadTooLargeException);
+	});
+
+	it('ne touche pas aux types non-image (application/pdf)', async () => {
+		await expect(checkImageDimensions(makePdfClean(), 'application/pdf')).resolves.toBeUndefined();
+	});
+
+	it('ne touche pas aux types non-image (video/mp4)', async () => {
+		await expect(checkImageDimensions(Buffer.alloc(32), 'video/mp4')).resolves.toBeUndefined();
+	});
+
+	it('fail-open si sharp ne peut pas décoder le buffer (format inconnu)', async () => {
+		// Buffer aléatoire qui ne correspond à aucun format image
+		const garbage = Buffer.from([0x00, 0x01, 0x02, 0x03, 0xde, 0xad, 0xbe, 0xef]);
+		await expect(checkImageDimensions(garbage, 'image/jpeg')).resolves.toBeUndefined();
+	});
+});
+
+// ── checkPdfJavaScript() ─────────────────────────────────────────────────────
+
+describe('checkPdfJavaScript()', () => {
+	it('passe pour un PDF propre', () => {
+		expect(() => checkPdfJavaScript(makePdfClean(), 'application/pdf')).not.toThrow();
+	});
+
+	it('rejette un PDF avec /JavaScript', () => {
+		expect(() => checkPdfJavaScript(makePdfWithJs(), 'application/pdf')).toThrow(
+			UnprocessableEntityException
+		);
+	});
+
+	it("rejette un PDF avec /JS suivi d'espace", () => {
+		const buf = Buffer.from('%PDF-1.4\n<</JS (alert(1))>>');
+		expect(() => checkPdfJavaScript(buf, 'application/pdf')).toThrow(UnprocessableEntityException);
+	});
+
+	it('ne touche pas aux types non-PDF (image/jpeg)', () => {
+		// même buffer qui contiendrait /JavaScript ne doit pas lever d'exception
+		const buf = Buffer.from('/JavaScript dans une image bidon');
+		expect(() => checkPdfJavaScript(buf, 'image/jpeg')).not.toThrow();
+	});
+
+	it('ne touche pas aux types non-PDF (application/zip)', () => {
+		const buf = Buffer.from('/JavaScript dans un zip bidon');
+		expect(() => checkPdfJavaScript(buf, 'application/zip')).not.toThrow();
+	});
+});
+
+// ── checkClamAv() ────────────────────────────────────────────────────────────
+
+describe('checkClamAv()', () => {
+	const originalEnv = process.env.CLAMAV_HOST;
+
+	afterEach(() => {
+		if (originalEnv === undefined) {
+			delete process.env.CLAMAV_HOST;
+		} else {
+			process.env.CLAMAV_HOST = originalEnv;
+		}
+	});
+
+	it("fail-open si CLAMAV_HOST n'est pas défini", async () => {
+		delete process.env.CLAMAV_HOST;
+		// aucune connexion réseau tentée, aucune exception
+		await expect(checkClamAv(Buffer.from('payload'))).resolves.toBeUndefined();
+	});
+
+	it('fail-open si le daemon est inaccessible (port fermé)', async () => {
+		// Port 1 est réservé et presque jamais ouvert : la connexion échoue rapidement
+		process.env.CLAMAV_HOST = '127.0.0.1';
+		process.env.CLAMAV_PORT = '1';
+		// Ne doit pas rejeter même si la connexion échoue
+		await expect(checkClamAv(Buffer.from('payload'))).resolves.toBeUndefined();
+		delete process.env.CLAMAV_PORT;
+	});
+});

--- a/src/modules/media/content-safety.validator.spec.ts
+++ b/src/modules/media/content-safety.validator.spec.ts
@@ -84,19 +84,58 @@ describe('checkPdfJavaScript()', () => {
 
 // ── checkClamAv() ────────────────────────────────────────────────────────────
 
+// Fabrique un mock de net.Socket qui simule une réponse clamd configurable.
+// Les événements sont émis de façon asynchrone (globalThis.setImmediate) pour laisser
+// le code enregistrer ses listeners avant que les données arrivent.
+function makeMockSocket(response: string, errorAfterConnect?: Error) {
+	const listeners: Record<string, ((...args: any[]) => void)[]> = {};
+
+	const socket = {
+		setTimeout: jest.fn(),
+		connect: jest.fn((_port: number, _host: string, cb: () => void) => {
+			globalThis.setImmediate(() => {
+				if (errorAfterConnect) {
+					(listeners['error'] ?? []).forEach((fn) => fn(errorAfterConnect));
+					return;
+				}
+				cb();
+				// Simule la réponse du daemon puis la fin de connexion
+				globalThis.setImmediate(() => {
+					(listeners['data'] ?? []).forEach((fn) => fn(Buffer.from(response)));
+					globalThis.setImmediate(() => {
+						(listeners['end'] ?? []).forEach((fn) => fn());
+					});
+				});
+			});
+		}),
+		write: jest.fn(),
+		destroy: jest.fn(),
+		on: jest.fn((event: string, fn: (...args: any[]) => void) => {
+			if (!listeners[event]) listeners[event] = [];
+			listeners[event].push(fn);
+			return socket;
+		}),
+	};
+	return socket;
+}
+
 describe('checkClamAv()', () => {
-	const originalEnv = process.env.CLAMAV_HOST;
+	const originalEnv = { host: process.env.CLAMAV_HOST, port: process.env.CLAMAV_PORT };
+
+	beforeEach(() => {
+		delete process.env.CLAMAV_HOST;
+		delete process.env.CLAMAV_PORT;
+	});
 
 	afterEach(() => {
-		if (originalEnv === undefined) {
-			delete process.env.CLAMAV_HOST;
-		} else {
-			process.env.CLAMAV_HOST = originalEnv;
-		}
+		if (originalEnv.host === undefined) delete process.env.CLAMAV_HOST;
+		else process.env.CLAMAV_HOST = originalEnv.host;
+		if (originalEnv.port === undefined) delete process.env.CLAMAV_PORT;
+		else process.env.CLAMAV_PORT = originalEnv.port;
+		jest.restoreAllMocks();
 	});
 
 	it("fail-open si CLAMAV_HOST n'est pas défini", async () => {
-		delete process.env.CLAMAV_HOST;
 		// aucune connexion réseau tentée, aucune exception
 		await expect(checkClamAv(Buffer.from('payload'))).resolves.toBeUndefined();
 	});
@@ -107,6 +146,39 @@ describe('checkClamAv()', () => {
 		process.env.CLAMAV_PORT = '1';
 		// Ne doit pas rejeter même si la connexion échoue
 		await expect(checkClamAv(Buffer.from('payload'))).resolves.toBeUndefined();
-		delete process.env.CLAMAV_PORT;
+	});
+
+	it('passe sans exception quand clamd répond OK (fichier sain)', async () => {
+		process.env.CLAMAV_HOST = '127.0.0.1';
+		process.env.CLAMAV_PORT = '3310';
+
+		const mockSocket = makeMockSocket('stream: OK');
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		jest.spyOn(require('net'), 'Socket').mockImplementation(() => mockSocket as any);
+
+		await expect(checkClamAv(Buffer.from('clean'))).resolves.toBeUndefined();
+	});
+
+	it('lève UnprocessableEntityException quand clamd répond FOUND (malware détecté)', async () => {
+		process.env.CLAMAV_HOST = '127.0.0.1';
+		process.env.CLAMAV_PORT = '3310';
+
+		const mockSocket = makeMockSocket('stream: Eicar-Test-Signature FOUND');
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		jest.spyOn(require('net'), 'Socket').mockImplementation(() => mockSocket as any);
+
+		await expect(checkClamAv(Buffer.from('eicar'))).rejects.toThrow(UnprocessableEntityException);
+	});
+
+	it('fail-open quand la connexion TCP aboutit mais le daemon renvoie une réponse inattendue', async () => {
+		process.env.CLAMAV_HOST = '127.0.0.1';
+		process.env.CLAMAV_PORT = '3310';
+
+		const mockSocket = makeMockSocket('stream: PARSE ERROR');
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		jest.spyOn(require('net'), 'Socket').mockImplementation(() => mockSocket as any);
+
+		// Réponse inattendue → warn log mais pas d'exception (fail-open)
+		await expect(checkClamAv(Buffer.from('unknown'))).resolves.toBeUndefined();
 	});
 });

--- a/src/modules/media/content-safety.validator.ts
+++ b/src/modules/media/content-safety.validator.ts
@@ -1,0 +1,158 @@
+import { Logger, PayloadTooLargeException, UnprocessableEntityException } from '@nestjs/common';
+import * as sharp from 'sharp';
+import * as net from 'net';
+
+const logger = new Logger('ContentSafetyValidator');
+
+// 50 Megapixels - un décodage complet au-delà de cette limite peut saturer le heap du pod
+// (ex. image 10000x5000 = 50MP, ~200MB en RGBA non-compressé → risque OOM/DoS)
+const MAX_PIXELS = 50_000_000;
+
+// Tokens PDF qui signalent du JavaScript embarqué (cf. spec ISO 32000-1 §12.6.4)
+// On scanne les 64 KB initiaux : les headers /JS apparaissent quasi-toujours dans le catalog
+const PDF_JS_SCAN_BYTES = 64 * 1024;
+const PDF_JS_TOKENS = ['/JS ', '/JavaScript', '/JS\r', '/JS\n', '/JS(', '/JS<'];
+
+// Types d'images supportés par sharp - les autres MIME (pdf, video, audio, zip) sont ignorés
+const IMAGE_MIME_TYPES = new Set([
+	'image/jpeg',
+	'image/png',
+	'image/gif',
+	'image/webp',
+	'image/heic',
+	'image/heif',
+]);
+
+/**
+ * Vérifie les dimensions d'une image AVANT décodage complet via sharp.metadata().
+ * Rejette si width * height > MAX_PIXELS (50 MP) pour bloquer les image bombs.
+ * Ne lance pas d'exception pour les types non-image (pdf, vidéo, etc.).
+ */
+export async function checkImageDimensions(buffer: Buffer, mimeType: string): Promise<void> {
+	const mime = mimeType.split(';')[0].trim().toLowerCase();
+	if (!IMAGE_MIME_TYPES.has(mime)) return;
+
+	let metadata: sharp.Metadata;
+	try {
+		metadata = await sharp(buffer, { failOn: 'none' }).metadata();
+	} catch (err) {
+		// sharp ne peut pas lire le format : on laisse passer, la validation
+		// magic-bytes plus haut a déjà confirmé la signature binaire
+		logger.warn(
+			`sharp.metadata() failed for mime=${mime}: ${err instanceof Error ? err.message : String(err)}`
+		);
+		return;
+	}
+
+	const { width, height } = metadata;
+	if (width === undefined || height === undefined) return;
+
+	const pixels = width * height;
+	if (pixels > MAX_PIXELS) {
+		throw new PayloadTooLargeException(
+			`Image dimensions ${width}x${height} (${pixels} px) exceed the ${MAX_PIXELS} px limit`
+		);
+	}
+}
+
+/**
+ * Détecte la présence de JavaScript embarqué dans un PDF.
+ * Lit uniquement les premiers PDF_JS_SCAN_BYTES pour éviter de charger un PDF entier en mémoire.
+ * Rejette avec 422 si un token /JS ou /JavaScript est trouvé.
+ * Ne fait rien pour les types non-PDF.
+ */
+export function checkPdfJavaScript(buffer: Buffer, mimeType: string): void {
+	const mime = mimeType.split(';')[0].trim().toLowerCase();
+	if (mime !== 'application/pdf') return;
+
+	const slice = buffer.subarray(0, PDF_JS_SCAN_BYTES).toString('latin1');
+	for (const token of PDF_JS_TOKENS) {
+		if (slice.includes(token)) {
+			throw new UnprocessableEntityException('PDF contains embedded JavaScript which is not permitted');
+		}
+	}
+}
+
+/**
+ * Stub ClamAV : se branche sur un daemon ClamAV si CLAMAV_HOST est défini.
+ * Si indisponible ou non configuré, fail-open avec un log warn (on ne bloque pas l'upload).
+ * Utilise le protocole INSTREAM de clamd (RFC-like) via une connexion TCP nue.
+ *
+ * Pour déployer : lancer clamd dans le même pod ou en sidecar, définir CLAMAV_HOST=127.0.0.1
+ * et CLAMAV_PORT=3310 (défaut clamd).
+ */
+export async function checkClamAv(buffer: Buffer): Promise<void> {
+	const host = process.env.CLAMAV_HOST;
+	if (!host) {
+		// ClamAV non configuré - fail-open intentionnel, pas un bug
+		return;
+	}
+
+	const port = parseInt(process.env.CLAMAV_PORT ?? '3310', 10);
+
+	try {
+		const result = await sendToClamd(host, port, buffer);
+		if (result.includes('FOUND')) {
+			const virus = result.split(':')[1]?.trim() ?? 'unknown';
+			logger.warn(`ClamAV détecté : ${virus}`);
+			throw new UnprocessableEntityException(`File rejected by antivirus scanner: ${virus}`);
+		}
+		if (!result.includes('OK')) {
+			logger.warn(`Réponse ClamAV inattendue: ${result}`);
+		}
+	} catch (err) {
+		if (err instanceof UnprocessableEntityException) throw err;
+		// Daemon inaccessible → fail-open avec warn pour ne pas bloquer les uploads légitimes
+		logger.warn(
+			`ClamAV inaccessible (${host}:${port}), upload autorisé par fail-open: ${err instanceof Error ? err.message : String(err)}`
+		);
+	}
+}
+
+/**
+ * Envoie le buffer au daemon clamd via le protocole INSTREAM.
+ * Format: "zINSTREAM\0" puis chunks <uint32-be-length><data> terminés par <uint32=0>.
+ */
+function sendToClamd(host: string, port: number, buffer: Buffer): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const socket = new net.Socket();
+		const timeout = 5000; // 5s max pour ne pas bloquer un upload
+
+		socket.setTimeout(timeout);
+
+		const chunks: Buffer[] = [];
+
+		socket.connect(port, host, () => {
+			// Commande INSTREAM en protocole null-terminated
+			socket.write('zINSTREAM\0');
+
+			// Chunk unique : longueur sur 4 octets big-endian + données
+			const lenBuf = Buffer.alloc(4);
+			lenBuf.writeUInt32BE(buffer.length, 0);
+			socket.write(lenBuf);
+			socket.write(buffer);
+
+			// Fin de stream : chunk de longueur 0
+			const endBuf = Buffer.alloc(4);
+			endBuf.writeUInt32BE(0, 0);
+			socket.write(endBuf);
+		});
+
+		socket.on('data', (chunk: Buffer) => chunks.push(chunk));
+
+		socket.on('end', () => {
+			socket.destroy();
+			resolve(Buffer.concat(chunks).toString('utf8').trim());
+		});
+
+		socket.on('timeout', () => {
+			socket.destroy();
+			reject(new Error('ClamAV connection timeout'));
+		});
+
+		socket.on('error', (err) => {
+			socket.destroy();
+			reject(err);
+		});
+	});
+}

--- a/src/modules/media/media.service.ts
+++ b/src/modules/media/media.service.ts
@@ -30,6 +30,7 @@ import { StorageService, StorageContext } from './storage.service';
 import { QuotaService } from './quota.service';
 import { GroupService } from './group.service';
 import { validateMagicBytes } from './magic-bytes.validator';
+import { checkImageDimensions, checkPdfJavaScript, checkClamAv } from './content-safety.validator';
 import { createClient } from '@redis/client';
 import { MediaContext, UploadMediaResponseDto, MediaMetadataDto } from './dto/upload-media.dto';
 import { REDIS_CLIENT } from './media.tokens';
@@ -225,6 +226,11 @@ export class MediaService {
 						`MIME type '${file.mimetype}' is not allowed for context '${context}'`
 					);
 				}
+
+				// WHISPR-1433: content safety - image bomb, PDF JS, ClamAV (fail-open)
+				await checkImageDimensions(blobBuffer, file.mimetype);
+				checkPdfJavaScript(blobBuffer, file.mimetype);
+				await checkClamAv(blobBuffer);
 
 				// WHISPR-362: Blob deduplication via SHA-256 (scoped per owner+context)
 				const sha256 = createHash('sha256').update(blobBuffer).digest('hex');


### PR DESCRIPTION
## Summary

- **Image bomb defense**: `sharp.metadata()` pre-decode check rejects images exceeding 50 MP (50 000 000 px) before any full decode - prevents heap saturation DoS
- **PDF JavaScript scan**: scans first 64 KB of PDF buffers for `/JS` and `/JavaScript` tokens (ISO 32000-1 §12.6.4) - returns 422 on hit
- **ClamAV stub**: TCP INSTREAM client wired to clamd when `CLAMAV_HOST` env is set, fail-open with warn log when daemon is unavailable or env absent - zero infra requirement to ship
- **SVG audit**: confirmed `image/svg+xml` is absent from all MIME allowlists - no SVG attack surface exists

## Audit findings

| Control | Status before | Status after |
|---------|--------------|--------------|
| Image dimensions pre-check | missing | sharp.metadata() gate 50 MP |
| PDF JavaScript | missing | 64 KB scan, 422 on hit |
| SVG XSS | N/A - SVG not in allowlist | confirmed absent |
| ClamAV | missing | fail-open stub, activates via env |
| Magic bytes (WHISPR-1371) | done (PR #108) | unchanged |

## Test plan

- [x] `checkImageDimensions()` - 200x200 passes, 7072x7072 rejects (PayloadTooLargeException)
- [x] `checkImageDimensions()` - non-image types skipped (pdf, mp4)
- [x] `checkImageDimensions()` - fail-open when sharp cannot decode
- [x] `checkPdfJavaScript()` - clean PDF passes, /JavaScript token rejects (422)
- [x] `checkPdfJavaScript()` - /JS followed by space rejects
- [x] `checkPdfJavaScript()` - non-PDF types skipped
- [x] `checkClamAv()` - fail-open when CLAMAV_HOST not set
- [x] `checkClamAv()` - fail-open when daemon unreachable
- [x] Full suite: 415 tests, 37 suites, all green

Closes WHISPR-1433