### PR TITLE
ci(cd): scope token sur infra pour debloquer le bump

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,10 +39,14 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.ACTIONS_CD }}
-          private_key: ${{ secrets.ACTIONS_CD_PRIVATE_KEY }}
+          app-id: ${{ secrets.ACTIONS_CD }}
+          private-key: ${{ secrets.ACTIONS_CD_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            media-service
+            infrastructure
 
       - name: Checkout media-service
         uses: actions/checkout@v4


### PR DESCRIPTION
Le step generate-github-app-token n'avait pas owner+repositories donc le token etait scope au repo courant uniquement, et le push sur whispr-messenger/infrastructure renvoyait 403. Pattern aligne sur mobile-app et messaging-service.