### PR TITLE
[WHISPR-645] ci(cd): bump preprod migration-job image tag alongside deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -130,6 +130,9 @@ jobs:
           yq -i ".spec.template.spec.containers[0].image = \"${FULL_IMAGE}\"" k8s/whispr/production/media-service/deployment.yaml
           yq -i ".spec.template.spec.containers[0].image = \"${FULL_IMAGE}\"" k8s/whispr/production/media-service/migration-job.yaml
           yq -i ".spec.template.spec.containers[0].image = \"${FULL_IMAGE}\"" k8s/whispr/preprod/media-service/deployment.yaml
+          if [ -f "k8s/whispr/preprod/media-service/migration-job.yaml" ]; then
+            yq -i ".spec.template.spec.containers[0].image = \"${FULL_IMAGE}\"" k8s/whispr/preprod/media-service/migration-job.yaml
+          fi
 
       - name: Verify update
         run: |
@@ -141,6 +144,10 @@ jobs:
           yq '.spec.template.spec.containers[0].image' k8s/whispr/production/media-service/migration-job.yaml
           echo "Updated preprod deployment manifest:"
           yq '.spec.template.spec.containers[0].image' k8s/whispr/preprod/media-service/deployment.yaml
+          if [ -f "k8s/whispr/preprod/media-service/migration-job.yaml" ]; then
+            echo "Updated preprod migration job manifest:"
+            yq '.spec.template.spec.containers[0].image' k8s/whispr/preprod/media-service/migration-job.yaml
+          fi
 
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
## Summary
- Ajoute le bump de `k8s/whispr/preprod/media-service/migration-job.yaml` dans le step Update image du CD
- Ajoute la verification du fichier dans le step Verify update
- Conditionnel (`if [ -f ... ]`) pour ne pas casser si le fichier n'existe pas encore

## Test plan
- [x] Diff CD workflow - ajout minimal, aucun code metier touche
- [ ] CI vert sur la PR

Closes WHISPR-645