### PR TITLE
fix(migrations): script prod utilisant dist/ au lieu de src/ TS

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"typeorm": "typeorm-ts-node-commonjs",
 		"migration:generate": "npm run typeorm -- migration:generate -d src/config/typeorm.config.ts",
 		"migration:run": "npm run typeorm -- migration:run -d src/config/typeorm.config.ts",
+		"migration:run:prod": "typeorm migration:run -d dist/migrations/migration.config.js",
 		"migration:revert": "npm run typeorm -- migration:revert -d src/config/typeorm.config.ts",
 		"docker:build": "docker build -t media-service .",
 		"docker:run": "docker run -p 3000:3000 media-service",


### PR DESCRIPTION
Fix régression migration Job ArgoCD PreSync : le script utilisait `src/config/typeorm.config.ts` qui n'existe pas dans l'image prod (only dist/ compilé).

Ajoute un script `migration:run:prod` qui pointe sur `dist/config/typeorm.config.js`.

Pair PR : infrastructure et user-service même fix.