### PR TITLE
fix(media): accept application/octet-stream for E2EE-encrypted messag…

### DIFF
--- a/src/modules/media/media.service.spec.ts
+++ b/src/modules/media/media.service.spec.ts
@@ -285,6 +285,46 @@ describe('MediaService', () => {
 			);
 		});
 
+		it('accepts application/octet-stream for E2EE-encrypted message uploads', async () => {
+			// E2EE blob : ciphertext opaque, ne matche aucune magic-byte connue.
+			// On verifie que (1) le validateur magic-bytes passe through pour
+			// application/octet-stream (pas dans MAGIC_MAP), et (2) l'allowlist
+			// MESSAGE accepte ce MIME.
+			const encryptedBuffer = Buffer.from([0x9f, 0x7c, 0x44, 0xa1, 0x02, 0x33, 0xbe, 0xee]);
+			const e2eeFile: Express.Multer.File = {
+				originalname: 'encrypted.bin',
+				mimetype: 'application/octet-stream',
+				size: encryptedBuffer.length,
+				buffer: encryptedBuffer,
+			} as unknown as Express.Multer.File;
+
+			const media = makeMedia({ contentType: 'application/octet-stream' });
+			mockMediaRepository.save.mockResolvedValue(media);
+
+			const result = await service.upload('user-uuid-1', e2eeFile, MediaContext.MESSAGE);
+
+			expect(result).toHaveProperty('media_id');
+			expect(mockStorageService.upload).toHaveBeenCalled();
+		});
+
+		it('still rejects application/octet-stream for AVATAR and GROUP_ICON contexts', async () => {
+			// L'exception octet-stream est scopee a MESSAGE pour ne pas affaiblir
+			// les uploads avatar / group icon ou un blob opaque n'a pas de sens.
+			const opaque: Express.Multer.File = {
+				originalname: 'encrypted.bin',
+				mimetype: 'application/octet-stream',
+				size: 8,
+				buffer: Buffer.from([0x9f, 0x7c, 0x44, 0xa1, 0x02, 0x33, 0xbe, 0xee]),
+			} as unknown as Express.Multer.File;
+
+			await expect(service.upload('user-uuid-1', opaque, MediaContext.AVATAR)).rejects.toThrow(
+				/not allowed for context/
+			);
+			await expect(service.upload('user-uuid-1', opaque, MediaContext.GROUP_ICON)).rejects.toThrow(
+				/not allowed for context/
+			);
+		});
+
 		// WHISPR-1371: defense-in-depth, magic-bytes doit etre verifie AVANT le MIME allowlist
 		it('rejects via magic-bytes before MIME allowlist when content is spoofed', async () => {
 			// MIME 'application/pdf' n'est pas dans l'allowlist AVATAR mais EST dans MAGIC_MAP.

--- a/src/modules/media/media.service.ts
+++ b/src/modules/media/media.service.ts
@@ -92,6 +92,13 @@ const CONTEXT_MIME_ALLOWLIST: Record<MediaContext, Set<string>> = {
 		'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 		'application/vnd.openxmlformats-officedocument.presentationml.presentation',
 		'application/zip',
+		// E2EE-encrypted blobs : le client (Signal) chiffre les bytes avant upload,
+		// donc les magic-bytes ne correspondent plus au MIME d'origine. On accepte
+		// `application/octet-stream` comme MIME opaque ; le MIME reel est preserve
+		// cote messaging-service dans la metadata du message pour le destinataire.
+		// `application/octet-stream` n'est pas dans MAGIC_MAP -> passe through le
+		// validateur magic-bytes sans rejection.
+		'application/octet-stream',
 	]),
 	[MediaContext.AVATAR]: new Set([
 		'image/jpeg',


### PR DESCRIPTION
…e uploads

When clients encrypt media before upload (Signal/E2EE) the ciphertext no longer matches the original image/video magic bytes, so the magic-bytes validator (WHISPR-360) was rejecting every E2EE message attachment with a
415. Add application/octet-stream as an allowed MIME for MESSAGE uploads only — the validator already passes through unknown MIME types, and the real content type is preserved in the message metadata client-side.

AVATAR and GROUP_ICON contexts keep their restrictive image-only allowlist.