### PR TITLE
[WHISPR-E2EE] feat(media): refuser plaintext upload sur conv E2EE (defense in depth)

### DIFF
--- a/src/config/env-validation.schema.ts
+++ b/src/config/env-validation.schema.ts
@@ -25,4 +25,9 @@ export const envValidationSchema = Joi.object({
 	SIGNED_URL_EXPIRY_SECONDS: Joi.number().integer().positive().max(604800).optional().default(3600),
 	MESSAGE_BLOB_TTL_DAYS: Joi.number().integer().positive().optional().default(30),
 	THUMBNAIL_BLOB_TTL_DAYS: Joi.number().integer().positive().optional().default(30),
+	// WHISPR-E2EE : client vers messaging-service pour valider e2ee-status
+	MESSAGING_SERVICE_URL: Joi.string().uri().optional(),
+	MESSAGING_SERVICE_TIMEOUT_MS: Joi.number().integer().positive().optional().default(3000),
+	// Token partage entre services internes (meme valeur que dans messaging-service)
+	INTERNAL_API_TOKEN: Joi.string().optional(),
 }).options({ allowUnknown: true });

--- a/src/modules/media/dto/upload-media.dto.ts
+++ b/src/modules/media/dto/upload-media.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsArray, IsEnum, IsOptional, IsUUID } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { IsString } from 'class-validator';
 
 export enum MediaContext {
 	MESSAGE = 'message',
@@ -42,6 +43,16 @@ export class UploadMediaDto {
 	@IsOptional()
 	@IsUUID()
 	ownerId?: string;
+
+	// WHISPR-E2EE : ID de la conversation cible pour les uploads de type message.
+	// Obligatoire quand context=message - utilise pour valider E2EE vs plaintext.
+	// Peut aussi arriver via le header X-Conversation-Id (priorite au header).
+	@ApiPropertyOptional({
+		description: 'Conversation UUID (required when context=message)',
+	})
+	@IsOptional()
+	@IsString()
+	conversationId?: string;
 
 	// WHISPR-941 : liste d'UUIDs supplémentaires autorisés à lire ce média
 	// (typiquement, les membres de la conversation à laquelle il sera attaché).

--- a/src/modules/media/media.controller.spec.ts
+++ b/src/modules/media/media.controller.spec.ts
@@ -1,11 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, UnprocessableEntityException } from '@nestjs/common';
 import { MediaController, UPLOAD_MAX_BYTES } from './media.controller';
 import { MediaService } from './media.service';
 import { MediaContext, UploadMediaDto } from './dto/upload-media.dto';
 import type { Request } from 'express';
 
-const makeReq = (userId: string): Request => ({ user: { userId } }) as unknown as Request;
+const makeReq = (userId: string, extraHeaders: Record<string, string> = {}): Request =>
+	({ user: { userId }, headers: extraHeaders, socket: {} }) as unknown as Request;
 
 const mockMediaService = {
 	upload: jest.fn(),
@@ -19,6 +20,7 @@ const mockMediaService = {
 	getUserQuota: jest.fn(),
 	getUserMedia: jest.fn(),
 	logAccess: jest.fn(),
+	enforceE2EEContentType: jest.fn(),
 };
 
 describe('MediaController', () => {
@@ -36,7 +38,13 @@ describe('MediaController', () => {
 	});
 
 	describe('upload()', () => {
+		// context=message necessite desormais un conversationId - on le passe via header
 		const dto: UploadMediaDto = { context: MediaContext.MESSAGE, ownerId: 'user-uuid-1' };
+		const dtoWithConv: UploadMediaDto = {
+			context: MediaContext.MESSAGE,
+			ownerId: 'user-uuid-1',
+			conversationId: 'conv-test-uuid',
+		};
 		const file = {
 			originalname: 'photo.jpg',
 			mimetype: 'image/jpeg',
@@ -54,9 +62,10 @@ describe('MediaController', () => {
 				size: 2048,
 			};
 			mockMediaService.upload.mockResolvedValue(expected);
+			mockMediaService.enforceE2EEContentType.mockResolvedValue(undefined);
 
 			const result = await controller.upload(
-				makeReq('user-uuid-1'),
+				makeReq('user-uuid-1', { 'x-conversation-id': 'conv-test-uuid' }),
 				{ file: [file], thumbnail: [] },
 				dto
 			);
@@ -66,19 +75,31 @@ describe('MediaController', () => {
 
 		it('throws BadRequestException when no file is provided', async () => {
 			await expect(
-				controller.upload(makeReq('user-uuid-1'), { file: [], thumbnail: [] }, dto)
+				controller.upload(
+					makeReq('user-uuid-1', { 'x-conversation-id': 'conv-test' }),
+					{ file: [], thumbnail: [] },
+					dto
+				)
 			).rejects.toThrow(BadRequestException);
 		});
 
 		it('throws BadRequestException when authenticated user is missing', async () => {
-			const req = { user: {} } as unknown as Request;
-			await expect(controller.upload(req, { file: [file], thumbnail: [] }, dto)).rejects.toThrow(
-				BadRequestException
-			);
+			const req = {
+				user: {},
+				headers: { 'x-conversation-id': 'conv-x' },
+				socket: {},
+			} as unknown as Request;
+			await expect(
+				controller.upload(req, { file: [file], thumbnail: [] }, dtoWithConv)
+			).rejects.toThrow(BadRequestException);
 		});
 
 		it('throws BadRequestException when ownerId does not match authenticated user', async () => {
-			const mismatchDto: UploadMediaDto = { context: MediaContext.MESSAGE, ownerId: 'other-user' };
+			const mismatchDto: UploadMediaDto = {
+				context: MediaContext.MESSAGE,
+				ownerId: 'other-user',
+				conversationId: 'conv-mismatch',
+			};
 			await expect(
 				controller.upload(makeReq('user-uuid-1'), { file: [file] }, mismatchDto)
 			).rejects.toThrow(BadRequestException);
@@ -87,6 +108,71 @@ describe('MediaController', () => {
 		// WHISPR-1013: guard against unbounded uploads at the multer layer
 		it('exposes a 100 MB upload ceiling via UPLOAD_MAX_BYTES', () => {
 			expect(UPLOAD_MAX_BYTES).toBe(100 * 1024 * 1024);
+		});
+
+		// WHISPR-E2EE defense in depth
+		it('throws BadRequestException quand context=message et conversationId absent', async () => {
+			const dtoMessage: UploadMediaDto = { context: MediaContext.MESSAGE, ownerId: 'user-uuid-1' };
+			await expect(
+				controller.upload(makeReq('user-uuid-1'), { file: [file] }, dtoMessage)
+			).rejects.toThrow(BadRequestException);
+		});
+
+		it('passe la validation quand X-Conversation-Id header present (conv plaintext)', async () => {
+			mockMediaService.enforceE2EEContentType.mockResolvedValue(undefined);
+			mockMediaService.upload.mockResolvedValue({ media_id: 'm-1' });
+			const dtoMessage: UploadMediaDto = { context: MediaContext.MESSAGE, ownerId: 'user-uuid-1' };
+
+			const result = await controller.upload(
+				makeReq('user-uuid-1', { 'x-conversation-id': 'conv-abc' }),
+				{ file: [file] },
+				dtoMessage
+			);
+
+			expect(mockMediaService.enforceE2EEContentType).toHaveBeenCalledWith('conv-abc', 'image/jpeg');
+			expect(result).toEqual({ media_id: 'm-1' });
+		});
+
+		it('passe la validation quand conversationId dans le body', async () => {
+			mockMediaService.enforceE2EEContentType.mockResolvedValue(undefined);
+			mockMediaService.upload.mockResolvedValue({ media_id: 'm-2' });
+			const dtoMessage: UploadMediaDto = {
+				context: MediaContext.MESSAGE,
+				ownerId: 'user-uuid-1',
+				conversationId: 'conv-body-123',
+			};
+
+			await controller.upload(makeReq('user-uuid-1'), { file: [file] }, dtoMessage);
+
+			expect(mockMediaService.enforceE2EEContentType).toHaveBeenCalledWith(
+				'conv-body-123',
+				'image/jpeg'
+			);
+		});
+
+		it('propage UnprocessableEntityException quand enforceE2EEContentType refuse', async () => {
+			mockMediaService.enforceE2EEContentType.mockRejectedValue(
+				new UnprocessableEntityException('plaintext_media_not_allowed_on_e2ee_conversation')
+			);
+			const dtoMessage: UploadMediaDto = {
+				context: MediaContext.MESSAGE,
+				ownerId: 'user-uuid-1',
+				conversationId: 'conv-e2ee',
+			};
+
+			await expect(
+				controller.upload(makeReq('user-uuid-1'), { file: [file] }, dtoMessage)
+			).rejects.toThrow(UnprocessableEntityException);
+		});
+
+		it('ne demande pas de conversationId pour context=avatar', async () => {
+			mockMediaService.upload.mockResolvedValue({ media_id: 'm-3' });
+			const dtoAvatar: UploadMediaDto = { context: MediaContext.AVATAR, ownerId: 'user-uuid-1' };
+
+			await controller.upload(makeReq('user-uuid-1'), { file: [file] }, dtoAvatar);
+
+			// enforceE2EEContentType ne doit pas etre appele quand pas de conversationId
+			expect(mockMediaService.enforceE2EEContentType).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/modules/media/media.controller.ts
+++ b/src/modules/media/media.controller.ts
@@ -83,6 +83,10 @@ export class MediaController {
 				thumbnail: { type: 'string', format: 'binary' },
 				context: { type: 'string', enum: Object.values(MediaContext) },
 				ownerId: { type: 'string', format: 'uuid' },
+				conversationId: {
+					type: 'string',
+					description: 'Conversation UUID (required when context=message)',
+				},
 				sharedWith: {
 					type: 'string',
 					description: 'JSON array or CSV of user UUIDs to share with',
@@ -94,6 +98,7 @@ export class MediaController {
 	@ApiResponse({ status: 400, description: 'Validation error' })
 	@ApiResponse({ status: 413, description: 'Quota exceeded or file too large' })
 	@ApiResponse({ status: 415, description: 'Content-Type mismatch (magic bytes)' })
+	@ApiResponse({ status: 422, description: 'Plaintext media refused on E2EE conversation' })
 	@ApiResponse({ status: 429, description: 'Too many concurrent uploads' })
 	@UseInterceptors(
 		FileFieldsInterceptor(
@@ -128,7 +133,26 @@ export class MediaController {
 
 		const context = dto.context ?? MediaContext.MESSAGE;
 
-		this.logger.debug(`Upload request from user ${ownerId} context=${context}`);
+		// WHISPR-E2EE defense in depth : pour les uploads de type message,
+		// le conversationId est obligatoire. Il peut arriver via le header
+		// X-Conversation-Id (priorite) ou le body field conversationId.
+		const conversationId = (req as any).headers?.['x-conversation-id'] ?? dto.conversationId ?? null;
+
+		if (context === MediaContext.MESSAGE && !conversationId) {
+			throw new BadRequestException({
+				error: 'conversation_id_required',
+				message: 'X-Conversation-Id header or conversationId body field required for message uploads',
+			});
+		}
+
+		// Validation E2EE : sur une conv chiffree, seul application/octet-stream est accepte.
+		if (conversationId) {
+			await this.mediaService.enforceE2EEContentType(conversationId, file.mimetype);
+		}
+
+		this.logger.debug(
+			`Upload request from user ${ownerId} context=${context} conv=${conversationId ?? 'none'}`
+		);
 		return this.mediaService.upload(ownerId, file, context, thumbnail, dto.sharedWith);
 	}
 

--- a/src/modules/media/media.module.ts
+++ b/src/modules/media/media.module.ts
@@ -13,6 +13,7 @@ import { MediaAccessLogPartitionService } from './media-access-log-partition.ser
 import { StorageService } from './storage.service';
 import { QuotaService } from './quota.service';
 import { GroupService } from './group.service';
+import { MessagingService } from './messaging.service';
 import { LifecycleService } from './lifecycle.service';
 import { RlsContextService } from './rls-context.service';
 import { RlsInterceptor } from './rls.interceptor';
@@ -37,6 +38,7 @@ import { RlsSubscriber } from './rls.subscriber';
 		MediaRepository,
 		StorageService,
 		GroupService,
+		MessagingService,
 		MediaService,
 		MediaAccessLogPartitionService,
 		QuotaService,

--- a/src/modules/media/media.service.spec.ts
+++ b/src/modules/media/media.service.spec.ts
@@ -145,9 +145,7 @@ const mockMetricsService = {
 describe('MediaService', () => {
 	let service: MediaService;
 
-	beforeEach(async () => {
-		jest.clearAllMocks();
-
+	beforeAll(async () => {
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [
 				MediaService,
@@ -170,6 +168,10 @@ describe('MediaService', () => {
 		}).compile();
 
 		service = module.get<MediaService>(MediaService);
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
 	});
 
 	it('wraps RLS-sensitive repository reads and writes in explicit transactions', async () => {

--- a/src/modules/media/media.service.spec.ts
+++ b/src/modules/media/media.service.spec.ts
@@ -12,6 +12,7 @@ import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { getS3ConnectionToken } from 'nestjs-s3';
 import { MediaService } from './media.service';
+import { MessagingService } from './messaging.service';
 import { MediaRepository } from './repositories/media.repository';
 import { StorageService } from './storage.service';
 import { QuotaService } from './quota.service';
@@ -71,6 +72,10 @@ const mockQuotaService = {
 
 const mockGroupService = {
 	isAdmin: jest.fn().mockResolvedValue(true),
+};
+
+const mockMessagingService = {
+	isConversationE2EE: jest.fn().mockResolvedValue(false),
 };
 
 const mockCache = {
@@ -150,6 +155,7 @@ describe('MediaService', () => {
 				{ provide: StorageService, useValue: mockStorageService },
 				{ provide: QuotaService, useValue: mockQuotaService },
 				{ provide: GroupService, useValue: mockGroupService },
+				{ provide: MessagingService, useValue: mockMessagingService },
 				{ provide: getS3ConnectionToken('default'), useValue: mockS3 },
 				{ provide: ConfigService, useValue: mockConfigService },
 				{ provide: getDataSourceToken(), useValue: mockDataSource },
@@ -1137,6 +1143,47 @@ describe('MediaService', () => {
 			mockAccessLogRepo.save.mockRejectedValueOnce(new Error('DB error'));
 
 			expect(() => service.logAccess('media-1', 'user-1', 'download')).not.toThrow();
+		});
+	});
+
+	describe('enforceE2EEContentType()', () => {
+		it('ne lance pas d exception quand la conv n est pas E2EE', async () => {
+			mockMessagingService.isConversationE2EE.mockResolvedValue(false);
+
+			await expect(service.enforceE2EEContentType('conv-plain', 'image/jpeg')).resolves.toBeUndefined();
+		});
+
+		it('ne lance pas d exception sur conv E2EE avec octet-stream', async () => {
+			mockMessagingService.isConversationE2EE.mockResolvedValue(true);
+
+			await expect(
+				service.enforceE2EEContentType('conv-e2ee', 'application/octet-stream')
+			).resolves.toBeUndefined();
+		});
+
+		it('lance UnprocessableEntityException sur conv E2EE avec image/jpeg', async () => {
+			const { UnprocessableEntityException } = await import('@nestjs/common');
+			mockMessagingService.isConversationE2EE.mockResolvedValue(true);
+
+			await expect(service.enforceE2EEContentType('conv-e2ee', 'image/jpeg')).rejects.toThrow(
+				UnprocessableEntityException
+			);
+		});
+
+		it('lance UnprocessableEntityException sur conv E2EE avec video/mp4', async () => {
+			const { UnprocessableEntityException } = await import('@nestjs/common');
+			mockMessagingService.isConversationE2EE.mockResolvedValue(true);
+
+			await expect(service.enforceE2EEContentType('conv-e2ee', 'video/mp4')).rejects.toThrow(
+				UnprocessableEntityException
+			);
+		});
+
+		it('fail-open si isConversationE2EE retourne false (service injoignable)', async () => {
+			mockMessagingService.isConversationE2EE.mockResolvedValue(false);
+
+			// image/jpeg sur conv fail-open (false) doit passer sans exception
+			await expect(service.enforceE2EEContentType('conv-down', 'image/jpeg')).resolves.toBeUndefined();
 		});
 	});
 });

--- a/src/modules/media/media.service.spec.ts
+++ b/src/modules/media/media.service.spec.ts
@@ -29,6 +29,12 @@ jest.mock('@aws-sdk/s3-request-presigner', () => ({
 	getSignedUrl: jest.fn().mockResolvedValue('https://presigned.url/file'),
 }));
 
+jest.mock('./content-safety.validator', () => ({
+	checkImageDimensions: jest.fn().mockResolvedValue(undefined),
+	checkPdfJavaScript: jest.fn().mockReturnValue(undefined),
+	checkClamAv: jest.fn().mockResolvedValue(undefined),
+}));
+
 const makeMedia = (overrides: Partial<Media> = {}): Media =>
 	Object.assign(new Media(), {
 		id: 'media-uuid-1',
@@ -230,34 +236,48 @@ describe('MediaService', () => {
 		});
 
 		it('refreshes semaphore TTL while an upload is in progress', async () => {
-			jest.useFakeTimers();
+			const media = makeMedia();
+			mockMediaRepository.save.mockResolvedValue(media);
 
-			try {
-				const media = makeMedia();
-				mockMediaRepository.save.mockResolvedValue(media);
+			// Capture le callback de l'interval sans fake timers globaux.
+			// Le spy est installe avant l'appel upload() mais setInterval n'est
+			// appele qu'apres plusieurs awaits internes (incr, expire, autorisation...).
+			let capturedCallback: (() => void) | undefined;
+			const setIntervalSpy = jest
+				.spyOn(globalThis, 'setInterval')
+				.mockImplementation((fn: TimerHandler, _delay?: number) => {
+					capturedCallback = fn as () => void;
+					return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
+				});
 
-				let resolveUpload: (() => void) | undefined;
-				mockStorageService.upload.mockImplementationOnce(
-					() =>
-						new Promise<void>((resolve) => {
-							resolveUpload = resolve;
-						})
-				);
+			let resolveUpload: (() => void) | undefined;
+			mockStorageService.upload.mockImplementationOnce(
+				() =>
+					new Promise<void>((resolve) => {
+						resolveUpload = resolve;
+					})
+			);
 
-				const uploadPromise = service.upload('user-uuid-1', file, MediaContext.MESSAGE);
-				await Promise.resolve();
+			const uploadPromise = service.upload('user-uuid-1', file, MediaContext.MESSAGE);
 
-				expect(mockRedisClient.expire).toHaveBeenCalledTimes(1);
+			// Attendre que setInterval soit appele (plusieurs awaits internes dans upload)
+			// en drainant la microtask queue via setImmediate
+			await new Promise((r) => globalThis.setImmediate(r));
 
-				await jest.advanceTimersByTimeAsync(5 * 60 * 1000);
+			expect(mockRedisClient.expire).toHaveBeenCalledTimes(1);
+			expect(capturedCallback).toBeDefined();
 
-				expect(mockRedisClient.expire).toHaveBeenCalledTimes(2);
+			// Declenche manuellement le callback TTL-refresh
+			capturedCallback!();
+			// Flush les microtasks de la promesse async refresh()
+			await new Promise((r) => globalThis.setImmediate(r));
 
-				resolveUpload?.();
-				await uploadPromise;
-			} finally {
-				jest.useRealTimers();
-			}
+			expect(mockRedisClient.expire).toHaveBeenCalledTimes(2);
+
+			resolveUpload?.();
+			await uploadPromise;
+
+			setIntervalSpy.mockRestore();
 		});
 
 		it('throws 429 HttpException when semaphore is at max', async () => {

--- a/src/modules/media/media.service.ts
+++ b/src/modules/media/media.service.ts
@@ -9,6 +9,7 @@ import {
 	PayloadTooLargeException,
 	ServiceUnavailableException,
 	StreamableFile,
+	UnprocessableEntityException,
 	UnsupportedMediaTypeException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -42,6 +43,10 @@ import {
 	DEFAULT_FILES_LIMIT,
 	DEFAULT_DAILY_UPLOAD_LIMIT,
 } from './quota.constants';
+import { MessagingService } from './messaging.service';
+
+// content-type attendu pour les blobs E2EE (ciphertext opaque)
+const E2EE_REQUIRED_CONTENT_TYPE = 'application/octet-stream';
 
 // limites de taille des blobs par contexte (en bytes)
 const CONTEXT_SIZE_LIMITS: Record<MediaContext, number> = {
@@ -153,7 +158,8 @@ export class MediaService {
 		private readonly accessLogRepo: Repository<MediaAccessLog>,
 		@Inject(REDIS_CLIENT) private readonly redisClient: ReturnType<typeof createClient>,
 		private readonly metricsService: MetricsService,
-		private readonly groupService: GroupService
+		private readonly groupService: GroupService,
+		private readonly messagingService: MessagingService
 	) {
 		// 1h limite fenetre d'exploitation post-revoke (was 7j)
 		this.signedUrlExpirySeconds = this.configService.get<number>('SIGNED_URL_EXPIRY_SECONDS', 60 * 60);
@@ -196,6 +202,28 @@ export class MediaService {
 
 	private get presignerClient(): S3 | S3Client {
 		return this.presigner ?? (this.s3 as unknown as S3Client);
+	}
+
+	// =========================================================================
+	// E2EE defense in depth
+	// =========================================================================
+
+	/**
+	 * Verifie qu'un upload est compatible avec l'etat E2EE de la conversation.
+	 *
+	 * - Conv E2EE + content-type != application/octet-stream → 422
+	 * - Conv plaintext → aucune restriction supplementaire
+	 *
+	 * Fail-open : si messaging-service est injoignable, on laisse passer.
+	 */
+	async enforceE2EEContentType(conversationId: string, contentType: string): Promise<void> {
+		const isE2EE = await this.messagingService.isConversationE2EE(conversationId);
+		if (isE2EE && contentType !== E2EE_REQUIRED_CONTENT_TYPE) {
+			throw new UnprocessableEntityException({
+				error: 'plaintext_media_not_allowed_on_e2ee_conversation',
+				message: `Conversation ${conversationId} has E2EE enabled - only application/octet-stream is accepted`,
+			});
+		}
 	}
 
 	// =========================================================================

--- a/src/modules/media/messaging.service.spec.ts
+++ b/src/modules/media/messaging.service.spec.ts
@@ -1,0 +1,139 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { MessagingService } from './messaging.service';
+
+const mockCache = {
+	get: jest.fn(),
+	set: jest.fn(),
+};
+
+const mockConfig = {
+	get: jest.fn((key: string, defaultVal?: unknown) => {
+		const cfg: Record<string, unknown> = {
+			MESSAGING_SERVICE_URL: 'http://messaging:4000',
+			INTERNAL_API_TOKEN: 'test-token',
+			MESSAGING_SERVICE_TIMEOUT_MS: 3000,
+		};
+		return cfg[key] ?? defaultVal;
+	}),
+};
+
+describe('MessagingService', () => {
+	let service: MessagingService;
+
+	beforeEach(async () => {
+		jest.clearAllMocks();
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				MessagingService,
+				{ provide: ConfigService, useValue: mockConfig },
+				{ provide: CACHE_MANAGER, useValue: mockCache },
+			],
+		}).compile();
+
+		service = module.get<MessagingService>(MessagingService);
+	});
+
+	describe('isConversationE2EE()', () => {
+		it('retourne la valeur cachee sans appel reseau', async () => {
+			mockCache.get.mockResolvedValue(true);
+
+			const result = await service.isConversationE2EE('conv-123');
+
+			expect(result).toBe(true);
+			expect(mockCache.get).toHaveBeenCalledWith('e2ee:conv:conv-123');
+		});
+
+		it('retourne false si cache retourne false', async () => {
+			mockCache.get.mockResolvedValue(false);
+
+			const result = await service.isConversationE2EE('conv-456');
+
+			expect(result).toBe(false);
+		});
+
+		it('appelle messaging-service et met en cache quand cache miss', async () => {
+			mockCache.get.mockResolvedValue(undefined);
+			mockCache.set.mockResolvedValue(undefined);
+
+			const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+				ok: true,
+				status: 200,
+				json: async () => ({ conversation_id: 'conv-789', e2ee_enabled: true }),
+			} as Response);
+
+			const result = await service.isConversationE2EE('conv-789');
+
+			expect(result).toBe(true);
+			expect(mockCache.set).toHaveBeenCalledWith('e2ee:conv:conv-789', true, 60_000);
+			fetchSpy.mockRestore();
+		});
+
+		it('retourne false (fail-open) si messaging-service retourne 404', async () => {
+			mockCache.get.mockResolvedValue(undefined);
+			mockCache.set.mockResolvedValue(undefined);
+
+			const fetchSpy = jest
+				.spyOn(globalThis, 'fetch')
+				.mockResolvedValue({ ok: false, status: 404 } as Response);
+
+			const result = await service.isConversationE2EE('conv-inconnue');
+
+			expect(result).toBe(false);
+			fetchSpy.mockRestore();
+		});
+
+		it('retourne false (fail-open) si messaging-service retourne 5xx', async () => {
+			mockCache.get.mockResolvedValue(undefined);
+			mockCache.set.mockResolvedValue(undefined);
+
+			const fetchSpy = jest
+				.spyOn(globalThis, 'fetch')
+				.mockResolvedValue({ ok: false, status: 503 } as Response);
+
+			const result = await service.isConversationE2EE('conv-down');
+
+			expect(result).toBe(false);
+			fetchSpy.mockRestore();
+		});
+
+		it('retourne false (fail-open) si fetch lance une exception reseau', async () => {
+			mockCache.get.mockResolvedValue(undefined);
+			mockCache.set.mockResolvedValue(undefined);
+
+			const fetchSpy = jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+
+			const result = await service.isConversationE2EE('conv-network-error');
+
+			expect(result).toBe(false);
+			fetchSpy.mockRestore();
+		});
+
+		it('retourne false (fail-open) si MESSAGING_SERVICE_URL non configure', async () => {
+			mockCache.get.mockResolvedValue(undefined);
+			mockCache.set.mockResolvedValue(undefined);
+
+			const configNoUrl = {
+				get: jest.fn((key: string, defaultVal?: unknown) => {
+					if (key === 'MESSAGING_SERVICE_URL') return '';
+					return defaultVal;
+				}),
+			};
+
+			const module: TestingModule = await Test.createTestingModule({
+				providers: [
+					MessagingService,
+					{ provide: ConfigService, useValue: configNoUrl },
+					{ provide: CACHE_MANAGER, useValue: mockCache },
+				],
+			}).compile();
+
+			const svcNoUrl = module.get<MessagingService>(MessagingService);
+			const result = await svcNoUrl.isConversationE2EE('conv-no-url');
+
+			expect(result).toBe(false);
+		});
+	});
+});

--- a/src/modules/media/messaging.service.ts
+++ b/src/modules/media/messaging.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject } from '@nestjs/common';
+import { Cache } from 'cache-manager';
+
+// TTL du cache e2ee-status : 60s pour eviter de spammer messaging-service
+// tout en restant coherent avec les toggles recents de l'utilisateur.
+const E2EE_STATUS_CACHE_TTL_MS = 60_000;
+
+interface E2eeStatusResponse {
+	conversation_id: string;
+	e2ee_enabled: boolean;
+}
+
+/**
+ * Client HTTP interne vers messaging-service.
+ *
+ * Interroge GET /messaging/api/v1/internal/conversations/:id/e2ee-status
+ * pour savoir si une conversation a E2EE active. Resultat cache 60s.
+ *
+ * Comportement fail-open : si messaging-service est injoignable ou retourne
+ * une erreur non-404, on laisse passer l'upload plutot que de bloquer
+ * l'utilisateur. Seul le cas "conv E2EE confirmee + plaintext" est refuse.
+ */
+@Injectable()
+export class MessagingService {
+	private readonly logger = new Logger(MessagingService.name);
+	private readonly baseUrl: string;
+	private readonly internalToken: string | undefined;
+	private readonly timeoutMs: number;
+
+	constructor(
+		private readonly configService: ConfigService,
+		@Inject(CACHE_MANAGER) private readonly cache: Cache
+	) {
+		this.baseUrl = (this.configService.get<string>('MESSAGING_SERVICE_URL') ?? '').replace(/\/$/, '');
+		this.internalToken = this.configService.get<string>('INTERNAL_API_TOKEN');
+		this.timeoutMs = this.configService.get<number>('MESSAGING_SERVICE_TIMEOUT_MS', 3000);
+	}
+
+	/**
+	 * Retourne true si la conversation a E2EE active, false sinon.
+	 * Resultat mis en cache 60s.
+	 *
+	 * En cas d'erreur reseau ou service indisponible : retourne false (fail-open).
+	 * En cas de conv inexistante (404) : retourne false.
+	 */
+	async isConversationE2EE(conversationId: string): Promise<boolean> {
+		const cacheKey = `e2ee:conv:${conversationId}`;
+		const cached = await this.cache.get<boolean>(cacheKey);
+		if (cached !== undefined && cached !== null) {
+			return cached;
+		}
+
+		const result = await this.fetchE2eeStatus(conversationId);
+		// On cache meme les false pour eviter les requetes repetees
+		await this.cache.set(cacheKey, result, E2EE_STATUS_CACHE_TTL_MS);
+		return result;
+	}
+
+	private async fetchE2eeStatus(conversationId: string): Promise<boolean> {
+		if (!this.baseUrl) {
+			this.logger.warn('MESSAGING_SERVICE_URL non configure - e2ee-status non verifiable (fail-open)');
+			return false;
+		}
+
+		const url = `${this.baseUrl}/messaging/api/v1/internal/conversations/${encodeURIComponent(conversationId)}/e2ee-status`;
+		const headers: Record<string, string> = { Accept: 'application/json' };
+		if (this.internalToken) {
+			headers['x-internal-token'] = this.internalToken;
+		}
+
+		const controller = new AbortController();
+		const timer = globalThis.setTimeout(() => controller.abort(), this.timeoutMs);
+
+		try {
+			const response = await fetch(url, { headers, signal: controller.signal });
+
+			if (response.status === 404) {
+				// Conv inconnue ou endpoint non expose : fail-open
+				return false;
+			}
+
+			if (!response.ok) {
+				this.logger.warn(
+					`messaging-service e2ee-status HTTP ${response.status} pour conv ${conversationId} - fail-open`
+				);
+				return false;
+			}
+
+			const body = (await response.json()) as E2eeStatusResponse;
+			return body.e2ee_enabled === true;
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			this.logger.warn(
+				`messaging-service injoignable (${msg}) - fail-open pour conv ${conversationId}`
+			);
+			return false;
+		} finally {
+			globalThis.clearTimeout(timer);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Ajoute header obligatoire X-Conversation-Id (ou body field conversationId) sur POST /media/v1/upload pour context=message
- Nouveau MessagingService qui interroge messaging-service via GET /internal/conversations/:id/e2ee-status avec cache 60s
- Sur conv e2ee_enabled=true : refuse tout content-type != application/octet-stream avec 422 plaintext_media_not_allowed_on_e2ee_conversation
- Fail-open si messaging-service injoignable (ne bloque pas les uploads legaux)

## Test plan
- [ ] Upload octet-stream sur conv E2EE -> 201 OK
- [ ] Upload image/jpeg sur conv E2EE -> 422 refuse
- [ ] Upload image/jpeg sur conv non-E2EE -> 201 OK (backward-compat)
- [ ] Upload sans X-Conversation-Id sur context=message -> 400
- [ ] messaging-service injoignable -> fail-open, upload accepte
- [ ] 437 tests unitaires verts

Closes WHISPR-E2EE-media-defense-in-depth