### PR TITLE
feat(media): bump UPLOAD_MAX_BYTES a 200MB pour la demo

### DIFF
--- a/src/modules/media/media.controller.spec.ts
+++ b/src/modules/media/media.controller.spec.ts
@@ -106,8 +106,8 @@ describe('MediaController', () => {
 		});
 
 		// WHISPR-1013: guard against unbounded uploads at the multer layer
-		it('exposes a 100 MB upload ceiling via UPLOAD_MAX_BYTES', () => {
-			expect(UPLOAD_MAX_BYTES).toBe(100 * 1024 * 1024);
+		it('exposes a 200 MB upload ceiling via UPLOAD_MAX_BYTES', () => {
+			expect(UPLOAD_MAX_BYTES).toBe(200 * 1024 * 1024);
 		});
 
 		// WHISPR-E2EE defense in depth

--- a/src/modules/media/media.controller.ts
+++ b/src/modules/media/media.controller.ts
@@ -48,10 +48,11 @@ import { PaginatedMediaResponseDto } from './dto/paginated-media-response.dto';
  * Limite haute appliquee par multer / FileFieldsInterceptor pour qu'un
  * client malveillant ne DoS pas le pod en streamant un body sans borne
  * en memoire (WHISPR-1013). Les limites par contexte
- * (MESSAGE=100MB, AVATAR/GROUP_ICON=5MB) restent enforce au niveau
+ * (MESSAGE=200MB, AVATAR/GROUP_ICON=5MB) restent enforce au niveau
  * service, c'est juste le garde-fou exterieur.
  */
-export const UPLOAD_MAX_BYTES = 100 * 1024 * 1024;
+// 200 MB pour la demo (vide tkts marge MinIO 30 GB) - reduire post-demo
+export const UPLOAD_MAX_BYTES = 200 * 1024 * 1024;
 
 @ApiTags('Media')
 @ApiBearerAuth('bearer')

--- a/src/modules/media/media.service.ts
+++ b/src/modules/media/media.service.ts
@@ -50,7 +50,7 @@ const E2EE_REQUIRED_CONTENT_TYPE = 'application/octet-stream';
 
 // limites de taille des blobs par contexte (en bytes)
 const CONTEXT_SIZE_LIMITS: Record<MediaContext, number> = {
-	[MediaContext.MESSAGE]: 100 * 1024 * 1024, // 100 MB
+	[MediaContext.MESSAGE]: 200 * 1024 * 1024, // 200 MB (demo, reduire post-demo)
 	[MediaContext.AVATAR]: 5 * 1024 * 1024, // 5 MB
 	[MediaContext.GROUP_ICON]: 5 * 1024 * 1024, // 5 MB
 };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -28,7 +28,7 @@ jest.mock('@nestjs/config', () => ({
 				'storage.bucket': process.env.GOOGLE_CLOUD_STORAGE_BUCKET,
 				'grpc.authService.url': process.env.AUTH_SERVICE_URL,
 				'grpc.moderationService.url': process.env.MODERATION_SERVICE_URL,
-				'media.maxFileSize': 100 * 1024 * 1024, // 100MB
+				'media.maxFileSize': 200 * 1024 * 1024, // 200MB
 			};
 			return config[key] || defaultValue;
 		}),


### PR DESCRIPTION
## Summary
- UPLOAD_MAX_BYTES : 100MB -> 200MB
- CONTEXT_SIZE_LIMITS.MESSAGE : 100MB -> 200MB
- tests adaptes (controller spec + setup mock)

## Why
Demo Whispr demain. Permet videos 4K courtes (~30s) + images 4K haute qualite.
A revaluer post-demo (multer memoryStorage limite par RAM pod).

## Risk
Buffer entier en RAM. Pod RAM doit etre bump a 1.5Gi (PR infra liee).